### PR TITLE
Ref issue #150 Get rid of _MethodList form solvcon.solver

### DIFF
--- a/doc/source/nestedloop.rst
+++ b/doc/source/nestedloop.rst
@@ -83,13 +83,11 @@ The base class is defined as:
   
   .. autoinstanceattribute:: substep_current
 
-  Derived classes of :py:class:`MeshSolver` should use the following method
-  :py:meth:`new_method_list` to make a new class variable :py:attr:`_MMNAMES`
-  to define numerical methods:
+  Time-marchers:
 
-  .. automethod:: new_method_list
+  .. automethod:: register_marcher
 
-  .. autoinstanceattribute:: _MMNAMES
+  .. autoattribute:: mmnames
 
 Useful entities are attached to the class :py:class:`MeshSolver`:
 

--- a/solvcon/parcel/bulk/solver.py
+++ b/solvcon/parcel/bulk/solver.py
@@ -186,9 +186,7 @@ class BulkSolver(solver.MeshSolver):
 
     ###########################################################################
     # Begin marching algorithm.
-    _MMNAMES = solver.MeshSolver.new_method_list()
-
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def update(self, worker=None):
         self._debug_check_array('soln', 'dsoln')
         self.alg.update(self.time, self.time_increment)
@@ -196,13 +194,13 @@ class BulkSolver(solver.MeshSolver):
         self.dsol[:,:,:] = self.dsoln[:,:,:]
         self._debug_check_array('sol', 'dsol')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsolt(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_solt()
         self._debug_check_array('solt')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_soln()
@@ -210,11 +208,11 @@ class BulkSolver(solver.MeshSolver):
             self._debug_check_array('soln', 'dsoln')
             self._debug_check_array(self.soln[self.ngstcell:,0]<=0)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcsoln(self, worker=None):
         if worker: self.exchangeibc('soln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.call_non_interface_bc('soln')
@@ -222,23 +220,23 @@ class BulkSolver(solver.MeshSolver):
             self._debug_check_array('soln', 'dsoln')
             self._debug_check_array(self.soln[self.ngstcell:,0]<=0)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calccfl(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_cfl()
         self._debug_check_array('cfl', 'ocfl', 'soln', 'dsoln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcdsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_dsoln()
         self._debug_check_array('soln', 'dsoln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcdsoln(self, worker=None):
         if worker: self.exchangeibc('dsoln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcdsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.call_non_interface_bc('dsoln')

--- a/solvcon/parcel/fake/solver.py
+++ b/solvcon/parcel/fake/solver.py
@@ -140,10 +140,7 @@ class FakeSolver(solver.MeshSolver):
 
     ###########################################################################
     # begin marching algorithm.
-    #: See :py:attr:`solvcon.solver.MeshSolver._MMNAMES`.
-    _MMNAMES = solver.MeshSolver.new_method_list()
-
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def update(self, worker=None):
         """
         Update the present solution arrays (:py:attr:`sol` and :py:attr:`dsol`)
@@ -172,7 +169,7 @@ class FakeSolver(solver.MeshSolver):
         self.sol[:,:] = self.soln[:,:]
         self.dsol[:,:,:] = self.dsoln[:,:,:]
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsoln(self, worker=None):
         """
         Advance :py:attr:`sol` to :py:attr:`soln`.  The calculation is
@@ -203,7 +200,7 @@ class FakeSolver(solver.MeshSolver):
         """
         self.create_alg().calc_soln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcsoln(self, worker=None):
         """
         Interchange BC for the :py:attr:`soln` array.  Only used for parallel
@@ -211,7 +208,7 @@ class FakeSolver(solver.MeshSolver):
         """
         if worker: self.exchangeibc('soln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calccfl(self, worker=None):
         """
         Calculate the CFL number.  For :py:class:`FakeSolver`, this method does
@@ -219,7 +216,7 @@ class FakeSolver(solver.MeshSolver):
         """
         self.marchret = -2.0
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcdsoln(self, worker=None):
         """
         Advance :py:attr:`dsol` to :py:attr:`dsoln`.  The calculation is
@@ -250,7 +247,7 @@ class FakeSolver(solver.MeshSolver):
         """
         self.create_alg().calc_dsoln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcdsoln(self, worker=None):
         """
         Interchange BC for the :py:attr:`dsoln` array.  Only used for parallel

--- a/solvcon/parcel/gas/solver.py
+++ b/solvcon/parcel/gas/solver.py
@@ -151,9 +151,7 @@ class GasSolver(sc.MeshSolver):
 
     ###########################################################################
     # Begin marching algorithm.
-    _MMNAMES = sc.MeshSolver.new_method_list()
-
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def update(self, worker=None):
         self._debug_check_array('soln', 'dsoln')
         self.alg.update(self.time, self.time_increment)
@@ -161,13 +159,13 @@ class GasSolver(sc.MeshSolver):
         self.dsol[:,:,:] = self.dsoln[:,:,:]
         self._debug_check_array('sol', 'dsol')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsolt(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_solt()
         self._debug_check_array('solt')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_soln()
@@ -175,11 +173,11 @@ class GasSolver(sc.MeshSolver):
             self._debug_check_array('soln', 'dsoln')
             self._debug_check_array(self.soln[self.ngstcell:,0]<=0)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcsoln(self, worker=None):
         if worker: self.exchangeibc('soln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.call_non_interface_bc('soln')
@@ -187,23 +185,23 @@ class GasSolver(sc.MeshSolver):
             self._debug_check_array('soln', 'dsoln')
             self._debug_check_array(self.soln[self.ngstcell:,0]<=0)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calccfl(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_cfl()
         self._debug_check_array('cfl', 'ocfl', 'soln', 'dsoln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcdsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.alg.calc_dsoln()
         self._debug_check_array('soln', 'dsoln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcdsoln(self, worker=None):
         if worker: self.exchangeibc('dsoln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcdsoln(self, worker=None):
         self._debug_check_array('sol', 'dsol')
         self.call_non_interface_bc('dsoln')

--- a/solvcon/parcel/linear/solver.py
+++ b/solvcon/parcel/linear/solver.py
@@ -176,38 +176,36 @@ class LinearSolver(solver.MeshSolver):
 
     ###########################################################################
     # Begin marching algorithm.
-    _MMNAMES = solver.MeshSolver.new_method_list()
-
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def update(self, worker=None):
         self.sol[:,:] = self.soln[:,:]
         self.dsol[:,:,:] = self.dsoln[:,:,:]
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsolt(self, worker=None):
         self.create_alg().calc_solt()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsoln(self, worker=None):
         self.create_alg().calc_soln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcsoln(self, worker=None):
         if worker: self.exchangeibc('soln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcsoln(self, worker=None):
         self.call_non_interface_bc('soln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcdsoln(self, worker=None):
         self.create_alg().calc_dsoln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcdsoln(self, worker=None):
         if worker: self.exchangeibc('dsoln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcdsoln(self, worker=None):
         self.call_non_interface_bc('dsoln')
     # End marching algorithm.

--- a/solvcon/parcel/vewave/solver.py
+++ b/solvcon/parcel/vewave/solver.py
@@ -193,41 +193,39 @@ class VewaveSolver(solver.MeshSolver):
 
     ###########################################################################
     # Begin marching algorithm.
-    _MMNAMES = solver.MeshSolver.new_method_list()
-
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def update(self, worker=None):
         self.alg.update(self.time, self.time_increment)
         self.sol[:,:] = self.soln[:,:]
         self.dsol[:,:,:] = self.dsoln[:,:,:]
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsolt(self, worker=None):
         #self.create_alg().calc_solt()
         self.alg.calc_solt()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcsoln(self, worker=None):
         #self.create_alg().calc_soln()
         self.alg.calc_soln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcsoln(self, worker=None):
         if worker: self.exchangeibc('soln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcsoln(self, worker=None):
         self.call_non_interface_bc('soln')
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def calcdsoln(self, worker=None):
         self.alg.calc_dsoln()
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def ibcdsoln(self, worker=None):
         if worker: self.exchangeibc('dsoln', worker=worker)
 
-    @_MMNAMES.register
+    @sc.MeshSolver.register_marcher
     def bcdsoln(self, worker=None):
         self.call_non_interface_bc('dsoln')
     # End marching algorithm.

--- a/solvcon/tests/test_solver.py
+++ b/solvcon/tests/test_solver.py
@@ -6,10 +6,16 @@ from __future__ import absolute_import, division, print_function
 
 import os
 from unittest import TestCase
-from ..testing import get_blk_from_sample_neu
-from ..solver import BaseSolver, BlockSolver
 
-class CustomBaseSolver(BaseSolver):
+import numpy as np
+
+import solvcon as sc
+from .. import solver
+from .. import testing
+from ..parcel.fake._algorithm import FakeAlgorithm
+
+
+class CustomBaseSolver(solver.BaseSolver):
     def __init__(self, **kw):
         kw['neq'] = 1
         super(CustomBaseSolver, self).__init__(**kw)
@@ -17,7 +23,7 @@ class CustomBaseSolver(BaseSolver):
         super(CustomBaseSolver, self).bind()
         self.val = 'bind'
 
-class CustomBlockSolver(BlockSolver):
+class CustomBlockSolver(solver.BlockSolver):
     MESG_FILENAME_DEFAULT = os.devnull
 
     _interface_init_ = ['cecnd', 'cevol']
@@ -47,7 +53,6 @@ class CustomBlockSolver(BlockSolver):
         self.cevol = empty((ngstcell+ncell, self.CLMFC+1), dtype=self.fpdtype)
 
     def create_alg(self):
-        from solvcon.parcel.fake.fake_algorithm import FakeAlgorithm
         alg = FakeAlgorithm()
         alg.setup_mesh(self.blk)
         alg.setup_algorithm(self)
@@ -84,8 +89,8 @@ class CustomBlockSolver(BlockSolver):
 
 class TestBase(TestCase):
     def test_base(self):
-        self.assertRaises(KeyError, BaseSolver)
-        bsvr = BaseSolver(neq=1)
+        self.assertRaises(KeyError, solver.BaseSolver)
+        bsvr = solver.BaseSolver(neq=1)
         self.assertEqual(getattr(bsvr, 'val', None), None)
         bsvr.bind()
         self.assertEqual(getattr(bsvr, 'val', None), None)
@@ -100,7 +105,7 @@ class TestFpdtype(TestCase):
     def test_fp(self):
         from ..dependency import str_of
         from ..conf import env
-        bsvr = BaseSolver(neq=1)
+        bsvr = solver.BaseSolver(neq=1)
         self.assertEqual(bsvr.fpdtype, env.fpdtype)
         self.assertEqual(bsvr.fpdtypestr, str_of(env.fpdtype))
 
@@ -108,26 +113,24 @@ class TestBlock(TestCase):
     neq = 1
 
     def test_simplex(self):
-        from ..testing import get_blk_from_sample_neu, get_blk_from_oblique_neu
-        svr = CustomBlockSolver(get_blk_from_oblique_neu(),
+        svr = CustomBlockSolver(testing.get_blk_from_oblique_neu(),
             neq=self.neq, enable_mesg=True)
         self.assertTrue(svr.all_simplex)
-        svr = CustomBlockSolver(get_blk_from_sample_neu(),
+        svr = CustomBlockSolver(testing.get_blk_from_sample_neu(),
             neq=self.neq, enable_mesg=True)
         self.assertFalse(svr.all_simplex)
 
     def test_incenter(self):
-        from ..testing import get_blk_from_sample_neu, get_blk_from_oblique_neu
-        svr = CustomBlockSolver(get_blk_from_oblique_neu(use_incenter=True),
+        svr = CustomBlockSolver(testing.get_blk_from_oblique_neu(use_incenter=True),
             neq=self.neq, enable_mesg=True)
         self.assertTrue(svr.use_incenter)
-        svr = CustomBlockSolver(get_blk_from_sample_neu(use_incenter=False),
+        svr = CustomBlockSolver(testing.get_blk_from_sample_neu(use_incenter=False),
             neq=self.neq, enable_mesg=True)
         self.assertFalse(svr.use_incenter)
 
     @staticmethod
     def _get_block():
-        return get_blk_from_sample_neu()
+        return testing.get_blk_from_sample_neu()
 
     @classmethod
     def _get_solver(cls, init=True):
@@ -175,3 +178,88 @@ class TestBlock(TestCase):
     def test_blkn(self):
         svr = self._get_solver()
         self.assertEqual(svr.svrn, None)
+
+
+class CustomMeshSolver(solver.MeshSolver):
+
+    MESG_FILENAME_DEFAULT = os.devnull
+
+    _interface_init_ = ['cecnd', 'cevol']
+
+    def __init__(self, blk, *args, **kw):
+        neq = kw.pop("neq")
+        super(CustomMeshSolver, self).__init__(blk, *args, **kw)
+        # data structure for C/FORTRAN.
+        self.blk = blk
+        # arrays.
+        ndim = self.ndim
+        ncell = self.ncell
+        ngstcell = self.ngstcell
+        ## solutions.
+        fpdtype = "float64"
+        self.neq = neq
+        self.sol = np.empty((ngstcell+ncell, neq), dtype=fpdtype)
+        self.soln = np.empty((ngstcell+ncell, neq), dtype=fpdtype)
+        self.dsol = np.empty((ngstcell+ncell, neq, ndim), dtype=fpdtype)
+        self.dsoln = np.empty((ngstcell+ncell, neq, ndim), dtype=fpdtype)
+        ## metrics.
+        self.cecnd = np.empty(
+            (ngstcell+ncell, sc.Block.CLMFC+1, ndim), dtype=fpdtype)
+        self.cevol = np.empty(
+            (ngstcell+ncell, sc.Block.CLMFC+1), dtype=fpdtype)
+
+    def create_alg(self):
+        alg = FakeAlgorithm()
+        alg.setup_mesh(self.blk)
+        alg.setup_algorithm(self)
+        return alg
+
+    ##################################################
+    # Time marchers
+    ##################################################
+    @solver.MeshSolver.register_marcher
+    def update(self, worker=None):
+        self.sol[:,:] = self.soln[:,:]
+        self.dsol[:,:,:] = self.dsoln[:,:,:]
+
+    @solver.MeshSolver.register_marcher
+    def calcsoln(self, worker=None):
+        self.create_alg().calc_soln()
+
+    @solver.MeshSolver.register_marcher
+    def ibcsoln(self, worker=None):
+        if worker: self.exchangeibc('soln', worker=worker)
+
+    @solver.MeshSolver.register_marcher
+    def calccfl(self, worker=None):
+        self.marchret = -2.0
+
+    @solver.MeshSolver.register_marcher
+    def calcdsoln(self, worker=None):
+        self.create_alg().calc_dsoln()
+
+    @solver.MeshSolver.register_marcher
+    def ibcdsoln(self, worker=None):
+        if worker: self.exchangeibc('dsoln', worker=worker)
+
+
+class TestMeshSolverBlock(TestCase):
+    neq = 1
+
+    def test_MMNAMES(self):
+        svr = CustomMeshSolver(
+            testing.get_blk_from_oblique_neu(use_incenter=True),
+            neq=self.neq, enable_mesg=True)
+        self.assertEqual(
+            ('update', 'calcsoln', 'ibcsoln', 'calccfl', 'calcdsoln',
+             'ibcdsoln'),
+            svr._MMNAMES)
+
+    def test_mmnames(self):
+        svr = CustomMeshSolver(
+            testing.get_blk_from_oblique_neu(use_incenter=True),
+            neq=self.neq, enable_mesg=True)
+        self.assertEqual(
+            ('update', 'calcsoln', 'ibcsoln', 'calccfl', 'calcdsoln',
+             'ibcdsoln'),
+            tuple(svr.mmnames))


### PR DESCRIPTION
This change beautifies a bit the `MeshSolver` API.  @tai271828, how do you think?

`_MethodList` is a slightly modified `list` that helps tracking the names of time-marching methods in a derived class of `solvcon.solver.MeshSolver` (aka `solvcon.MeshSolver`).  But it's not a straight-forward design.  In the subclass, a `_MethodList` needs to be instantiated as a class attribute (by calling `MeshSolver.new_method_list()`) as `_MMNAMES`.  A time-marching method needs to be decorated by `_MMNAMES.register`.

By following [the trick used by Django](http://blog.hirokiky.org/2013/11/04/getting_the_definition_order_of_class_attributes_in_python.html), we can simplify the design.  Instead of using a special list object, we let `_MMNAMES` be an ordinary `tuple`.  Each time-marching method is decorated by `MeshSolver.register_marcher` (instead of the decorator `_MMNAMES.register`, which doesn't exist anymore), which adds an attribute to track the order where the method is defined in the class.  The metaclass `MeshSolverMeta` extracts the order mark and create the `_MMNAMES` tuple.
