### PR TITLE
remove unused package gcc for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       #- llvm-toolchain-precise
     packages:
       # install toolchains
-      - gcc-6
       - g++-6
       #- clang-3.7
       - liblapack-pic


### PR DESCRIPTION
We introduce c++ code, which is based on c++14, recently. We only need newer c++ compiler so gcc is unused.
