### PR TITLE
Fix pickling for Block and Table objects (issue #135)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
 addons:
   apt:
     packages:
+      - openssh-client
+      - openssh-server
       - liblapack-pic
       - liblapack-dev
 
@@ -36,6 +38,10 @@ matrix:
       env: TRAVIS_PYTHON_VERSION="3.5"
 
 before_install:
+  # Configure ssh
+  - ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
+  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+  - ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
   # Install minimal conda
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
@@ -78,6 +84,8 @@ script:
   - cd ${TRAVIS_BUILD_DIR}
   - python setup.py build_ext --inplace
   - nosetests --with-doctest
+  - nosetests ftests/parallel/test_builtin.py
+  - nosetests ftests/parallel/test_rpc.py
   # Package
   - cd ${TRAVIS_BUILD_DIR}
   - contrib/release.sh

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -12,3 +12,5 @@ cd SOLVCON-${SCVER}
 python setup.py build_ext --inplace
 # test.
 nosetests --with-doctest
+nosetests ftests/parallel/test_builtin.py
+nosetests ftests/parallel/test_rpc.py

--- a/ftests/parallel/test_rpc.py
+++ b/ftests/parallel/test_rpc.py
@@ -27,7 +27,7 @@ class TestSecureShell(TestCase):
                 'import sys, os',
                 'sys.stdout.write(os.environ["A_TEST_ENV"])'
             ], envar={'A_TEST_ENV': 'A_TEST_VALUE'}, stdout=PIPE),
-            'A_TEST_VALUE'
+            b'A_TEST_VALUE'
         )
 
     def test_shell(self):
@@ -36,7 +36,7 @@ class TestSecureShell(TestCase):
         self.assertEqual(remote.shell([
                 'echo "A_TEST_VALUE"',
             ]),
-            'A_TEST_VALUE\n'
+            b'A_TEST_VALUE\n'
         )
 
 # vim: set ff=unix fenc=utf8 ft=python ai et sw=4 ts=4 tw=79:

--- a/solvcon/block.py
+++ b/solvcon/block.py
@@ -292,6 +292,17 @@ class Block(with_metaclass(BlockMeta)):
         # sanity check.
         self.check_sanity()
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        for name in self.TABLE_NAMES:
+            table = getattr(self, 'tb'+name)
+            setattr(self, name, table.B)
+            setattr(self, 'gst'+name, table.G)
+            setattr(self, 'sh'+name, table.F)
+
     def check_sanity(self):
         self.create_msh()
 

--- a/solvcon/case_legacy.py
+++ b/solvcon/case_legacy.py
@@ -43,6 +43,7 @@ import os
 import sys
 import time
 import traceback
+from numbers import Number
 from .py3kcompat import StringIO
 import signal
 from .py3kcompat import pickle
@@ -768,7 +769,7 @@ for node in $nodes; do rsh $node killall %s; done
             # print.
             self.info(('%%0%dd ->' % dwidth) % iblk)
             for pair in ifacelist:
-                if pair < 0:
+                if isinstance(pair, Number) and pair < 0:
                     stab = '-' * (2*dwidth+1)
                 else:
                     stab = '-'.join([('%%0%dd'%dwidth)%item for item in pair])

--- a/solvcon/march.cpp
+++ b/solvcon/march.cpp
@@ -195,6 +195,19 @@ PYBIND11_PLUGIN(march) {
             "_bodypart",
             [](LookupTableCore & tbl) { return Table(tbl).body(); },
             "Body-part array without setter.")
+        .def("__getstate__", [](LookupTableCore & tbl) {
+            return py::make_tuple(tbl.nghost(), tbl.nbody(), tbl.dims(), (long)tbl.datatypeid(), Table(tbl).full());
+        })
+        .def("__setstate__", [](LookupTableCore & tbl, py::tuple tpl) {
+            if (tpl.size() != 5) { throw std::runtime_error("Invalid state for Table (LookupTableCore)!"); }
+            index_type nghost = tpl[0].cast<index_type>();
+            index_type nbody  = tpl[1].cast<index_type>();
+            std::vector<index_type> dims = tpl[2].cast<std::vector<index_type>>();
+            DataTypeId datatypeid = static_cast<DataTypeId>(tpl[3].cast<long>());
+            py::array src = tpl[4].cast<py::array>();
+            new (&tbl) LookupTableCore(nghost, nbody, dims, datatypeid);
+            Table::CopyInto(Table(tbl).full(), src);
+        });
     ;
 
     py::class_< BoundaryData >(mod, "BoundaryData", "Data of a boundary condition.")

--- a/solvcon/solver_legacy.py
+++ b/solvcon/solver_legacy.py
@@ -36,6 +36,7 @@ Definition of the structure of solvers.
 from __future__ import absolute_import, division, print_function
 
 
+from numbers import Number
 from ctypes import Structure
 
 from .py3kcompat import with_metaclass
@@ -624,7 +625,7 @@ class BlockSolver(BaseSolver):
         # grab peer index.
         ibclist = list()
         for pair in ifacelist:
-            if pair < 0:
+            if isinstance(pair, Number) and pair < 0:
                 ibclist.append(pair)
             else:
                 assert len(pair) == 2
@@ -645,7 +646,7 @@ class BlockSolver(BaseSolver):
         threads = list()
         for ibc in self.ibclist:
             # check if sleep or not.
-            if ibc < 0:
+            if isinstance(ibc, Number) and ibc < 0:
                 continue
             bc, sendn, recvn = ibc
             # determine callable and arguments.

--- a/solvcon/tests/test_table.py
+++ b/solvcon/tests/test_table.py
@@ -31,10 +31,10 @@ from __future__ import absolute_import, division, print_function
 
 
 import unittest
+from ..py3kcompat import pickle
 
 import numpy as np
 
-from .. import py3kcompat
 from ..march import Table
 
 
@@ -138,5 +138,22 @@ class TestTableParts(unittest.TestCase):
         self.assertEqual((2,4,5), tbl._bodypart.shape)
         self.assertEqual(list(range(4*5,3*4*5)), list(tbl.B.ravel()))
         self.assertEqual(list(range(4*5,3*4*5)), list(tbl._bodypart.ravel()))
+
+
+class TestTablePickle(unittest.TestCase):
+
+    def test_dumps(self):
+        tbl = Table(2, 4, 5)
+        # pybind11 only supports protocol v2 (on 2016/7/26)!
+        pkl = pickle.dumps(tbl, 2)
+
+    def test_loads(self):
+        otbl = Table(2, 4, 5)
+        otbl.F = np.arange(otbl.F.size).reshape((6,5))
+        # pybind11 only supports protocol v2 (on 2016/7/26)!
+        pkl = pickle.dumps(otbl, 2)
+        # load it back
+        ltbl = pickle.loads(pkl)
+        self.assertEqual(np.arange(otbl.F.size).tolist(), ltbl.F.ravel().tolist())
 
 # vim: set fenc=utf8 ff=unix nobomb ai et sw=4 ts=4 tw=79:


### PR DESCRIPTION
ftests/parallel/test_builtin.py and ftests/parallel/test_rpc.py have been failing for a long time.  The reasons were:
1. Pickling wasn't properly implemented for the Cython-based Table (changed from ctypes long time ago) and the current C++-based implementation.
2. They're not updated to Python 3.

This change fixes the incompatibility.
