### PR TITLE
Add more path candidates to search header files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,9 @@ def make_pybind11_extension(
     rpathflag = '-Wl,-rpath,%s/lib' % sys.exec_prefix
     if "CONDA_PREFIX" in os.environ:
         include_dirs.append(os.path.join(os.environ["CONDA_PREFIX"], "include"))
+    else:
+        include_dirs.append(os.path.join("/usr/include/scotch"))
+        include_dirs.append(os.path.join("/usr/include/metis"))
     if extra_compile_args is None: extra_compile_args = []
     extra_compile_args.extend([
         '-Wall',


### PR DESCRIPTION
The header files, scotch.h and metis.h, are expected to be provided by `<CONDA_PREFIX>/include` and the other paths. This commit provides more path candidates to find these headers, so we could use more platforms or build environment managements to build SOLVCON source code.

The recent commit https://github.com/solvcon/solvcon/commit/1f70de3293f037102e4e1f5123e23af8d471c1e5#diff-2eeaed663bd0d25b7e608891384b7298R125 introduces the usage of CONDA_PREFIX to define the location to access SCOTCH.

In `setup.py`

```
+    if "CONDA_PREFIX" in os.environ:
+        include_dirs.append(os.path.join(os.environ["CONDA_PREFIX"], "include"))
```

This limits users and developers to usage of conda, the environment management system. We may want to run or build SOLVCON in different platforms or environments. For example, `scotch.h` is under `/usr/include/scotch` on Ubuntu Trusty and Ubuntu Xenial distribution. The current search paths do not try to search the header there, and this causes build failure. A user or developer may not want to use conda but the Ubuntu system itself. This commit could help us to use not only conda but also the other systems to build the code.

**Test case**
1. Make sure you have scotch.h and metis.h in your build system. In this test case, Ubuntu Trusty and Ubuntu Xenial are the target systems.
2. Fetch the SOLVCON source code.
3. Issue `python setup.py build_ext setup.py` to build the code.

**Expected result**
Successfully build the source code, and pass unit tests and ftest.
