### PR TITLE
Follow up pybind11 to 2.0.0rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # Useful for debugging any issues with conda
+  - which python; python --version
   - conda info -a
   # Debug information of compiler
   - which $CXX; $CXX --version

--- a/contrib/devenv/create.sh
+++ b/contrib/devenv/create.sh
@@ -8,5 +8,10 @@ fi
 SCDEVENV_DST=${SCDEVENV_SRC}/../../build/${SCDEVENV_DST}
 echo "Create environment at ${SCDEVENV_DST}"
 mkdir -p ${SCDEVENV_DST}
-conda create -p ${SCDEVENV_DST}/install --no-default-packages -y python
+if [ "3" == "`python -c 'import sys; sys.stdout.write(str(sys.version_info.major))'`" ] ; then
+  # Fix version to 3.5 before conda Python 3.6 stabilizes
+  conda create -p ${SCDEVENV_DST}/install --no-default-packages -y python=3.5
+else
+  conda create -p ${SCDEVENV_DST}/install --no-default-packages -y python
+fi
 cp -f ${SCDEVENV_SRC}/start ${SCDEVENV_DST}/start


### PR DESCRIPTION
Pybind11 updates:

- `object(handle, bool)` is deprecated, and reinterpret_{borrow,steal} is encouraged instead.
- Casting is updated.
- `def_property_readonly_static()` requires `metaclass`.

Python 3.6 released and other conda packages haven't been updated yet.  Keep SOLVCON to use 3.5 temporarily.