### PR TITLE
Ref issue #178 fix hdf4 compatibility.

### DIFF
--- a/contrib/conda.sh
+++ b/contrib/conda.sh
@@ -2,6 +2,8 @@
 conda install -y \
   cmake six setuptools pip sphinx ipython jupyter \
   cython numpy netcdf4 nose paramiko boto graphviz
+# issue #178
+conda install -y hdf4=4.2.12
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
 conda install -y -c https://conda.anaconda.org/yungyuc \
   gmsh scotch


### PR DESCRIPTION
Fix the issue by fixing hdf4 version to 4.2.12. This fix may be removed
or changed to use another version in the future if the expected
libmfhdf.so.0 is provided again.

The steps to reproduce the issue and verify the fix have been described in the issue report (issue #178).