### PR TITLE
Add probe hook prototype

### DIFF
--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -65,15 +65,19 @@ class DiaphragmIAnchor(sc.MeshAnchor):
         svr.soln[:,2].fill(0.0)
         if svr.ndim == 3:
             svr.soln[:,3].fill(0.0)
-        # pressure
-        svr.soln[:,svr.ndim+1].fill(self.p1)
-        # set.
+        # total energy of perfect gas without kinetic energy
+        svr.soln[:,svr.ndim+1].fill(self.p1/(gamma-1))
+        # the diaphragm localtion along the tube
         tube_middle = self.tube_height / 2
+        # get coordination of cells in one side of the tube
         slct_int = svr.blk.clcnd[:,2] > tube_middle
+        # get coordination of cells in one side of the tube
         slct_gst = svr.blk.gstclcnd[:,2] > tube_middle
         slct = np.concatenate((slct_gst, slct_int))
+        # initialize the data in one side of the tube
         svr.soln[slct,0] = self.rho2
-        svr.soln[slct,svr.ndim+1] = self.p2
+        # total energy of pergect gas without kinetic energy
+        svr.soln[slct,svr.ndim+1] = self.p2/(gamma-1)
         # update.
         svr.sol[:] = svr.soln[:]
 

--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -45,7 +45,7 @@ from solvcon.parcel import gas  # A specific SOLVCON solver package we'll use
 
 class DiaphragmIAnchor(sc.MeshAnchor):
     """
-    diaphragm initialization
+    diaphragm initialization anchor
     """
     def __init__(self, svr, **kw):
         self.rho1 = float(kw.pop('rho1'))
@@ -64,13 +64,17 @@ class DiaphragmIAnchor(sc.MeshAnchor):
         svr.soln[:,2].fill(0.0)
         if svr.ndim == 3:
             svr.soln[:,3].fill(0.0)
-        svr.soln[:,svr.ndim+1].fill(self.p1/(gamma-1))
+        # pressure
+        svr.soln[:,svr.ndim+1].fill(self.p1)
         # set.
+        # TODO: 0.5 is currently hard-coded for the half of the height of the tube.
+        # Make it more general by transfer the tube to locate the middle of the
+        # tube at the coordinate origin, or other ways.
         slct_int = svr.blk.clcnd[:,2] > 0.5
         slct_gst = svr.blk.gstclcnd[:,2] > 0.5
         slct = np.concatenate((slct_gst, slct_int))
         svr.soln[slct,0] = self.rho2
-        svr.soln[slct,svr.ndim+1] = self.p2/(gamma-1)
+        svr.soln[slct,svr.ndim+1] = self.p2
         # update.
         svr.sol[:] = svr.soln[:]
 

--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -78,6 +78,33 @@ class DiaphragmIAnchor(sc.MeshAnchor):
         svr.sol[:] = svr.soln[:]
 
 
+class TubeProbe(gas.ProbeHook):
+    """
+    Place a probe for the flow properties in the tube.
+    """
+
+    def __init__(self, cse, **kw):
+        """
+        Provide basic information to the probe hook.
+        """
+        # define where to probe
+        poi = ('poi', 0.0, 0.0, 0.0)
+        # provide coordination and spec list information to the probe hook.
+        kw['coords'] = (poi,)
+        kw['speclst'] = ['rho', 'p']
+        super(TubeProbe, self).__init__(cse, **kw)
+
+    def postloop(self):
+        """
+        Dump the probe data in the end.
+        """
+        super(TubeProbe, self).postloop()
+        rho, p = self.points[0].vals[-1][1:]
+        self.info('Probe result at %s:\n' % self.points[0])
+        self.info('- rho = %.3f \n' % rho)
+        self.info('- p = %.3f \n' % p)
+
+
 class SodtubeMesher(object):
     """
     Representation of a Sod tube and the Gmsh meshing helper.
@@ -197,10 +224,14 @@ def tube_base(casename=None,
               gamma=gamma, rho1=rho1, p1=p1, rho2=rho2, p2=p2,
               tube_height=tube_height)
     cse.defer(gas.PhysicsAnchor, rsteps=ssteps)
+    # probe the data, so this anchor should follow gas.PhysicsAnchor
     # Report information while calculating.
     cse.defer(gas.ProgressHook, linewidth=ssteps / psteps, psteps=psteps)
     cse.defer(gas.CflHook, fullstop=False, cflmax=10.0, psteps=ssteps)
+    # save the info each psteps
     cse.defer(gas.MeshInfoHook, psteps=ssteps, show_bclist=True)
+    # summarize the data fetched by TubeAnchor
+    cse.defer(TubeProbe, psteps=ssteps)
     # cse.defer(ReflectionProbe, rect=mesher, relation=relation, psteps=ssteps)
     # Store data.
     cse.defer(gas.PMarchSave,

--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -53,6 +53,7 @@ class DiaphragmIAnchor(sc.MeshAnchor):
         self.p1 = float(kw.pop('p1'))
         self.p2 = float(kw.pop('p2'))
         self.gamma = float(kw.pop('gamma'))
+        self.tube_height = float(kw.pop('tube_height'))
         super(DiaphragmIAnchor, self).__init__(svr, **kw)
 
     def provide(self):
@@ -67,11 +68,9 @@ class DiaphragmIAnchor(sc.MeshAnchor):
         # pressure
         svr.soln[:,svr.ndim+1].fill(self.p1)
         # set.
-        # TODO: 0.5 is currently hard-coded for the half of the height of the tube.
-        # Make it more general by transfer the tube to locate the middle of the
-        # tube at the coordinate origin, or other ways.
-        slct_int = svr.blk.clcnd[:,2] > 0.5
-        slct_gst = svr.blk.gstclcnd[:,2] > 0.5
+        tube_middle = self.tube_height / 2
+        slct_int = svr.blk.clcnd[:,2] > tube_middle
+        slct_gst = svr.blk.gstclcnd[:,2] > tube_middle
         slct = np.concatenate((slct_gst, slct_int))
         svr.soln[slct,0] = self.rho2
         svr.soln[slct,svr.ndim+1] = self.p2
@@ -170,7 +169,8 @@ def tube_base(casename=None,
     ############################################################################
 
     # Create the mesh generator.  Keep it for later use.
-    mesher = SodtubeMesher(center=0.0, radius=0.05, height=1.0,
+    tube_height = 1.0
+    mesher = SodtubeMesher(center=0.0, radius=0.05, height=tube_height,
                            edgelength=edgelength)
     # Set up case.
     cse = gas.GasCase(
@@ -194,7 +194,8 @@ def tube_base(casename=None,
                                        'dsoln': 0.0, 'amsca': gamma})
     # cse.defer(gas.DensityInitAnchor, rho=density)
     cse.defer(DiaphragmIAnchor,
-              gamma=gamma, rho1=rho1, p1=p1, rho2=rho2, p2=p2)
+              gamma=gamma, rho1=rho1, p1=p1, rho2=rho2, p2=p2,
+              tube_height=tube_height)
     cse.defer(gas.PhysicsAnchor, rsteps=ssteps)
     # Report information while calculating.
     cse.defer(gas.ProgressHook, linewidth=ssteps / psteps, psteps=psteps)

--- a/sandbox/gas/tube/paraview/view-p.py
+++ b/sandbox/gas/tube/paraview/view-p.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#### import the simple module from the paraview
+from paraview.simple import *
+#### disable automatic camera reset on 'Show'
+paraview.simple._DisableFirstRenderCameraReset()
+
+# create a new 'XML Unstructured Grid Reader'
+tube_0 = XMLUnstructuredGridReader(FileName=['../result/tube_0000.vtu', '../result/tube_0200.vtu', '../result/tube_0400.vtu', '../result/tube_0600.vtu'])
+tube_0.CellArrayStatus = ['M', 'T', 'ke', 'p', 'rho', 'sch', 'soln[0]', 'soln[1]', 'soln[2]', 'soln[3]', 'soln[4]', 'v']
+
+# get animation scene
+animationScene1 = GetAnimationScene()
+
+# update animation scene based on data timesteps
+animationScene1.UpdateAnimationUsingDataTimeSteps()
+
+# Properties modified on tube_0
+tube_0.CellArrayStatus = ['p']
+
+# get active view
+renderView1 = GetActiveViewOrCreate('RenderView')
+# uncomment following to set a specific view size
+# renderView1.ViewSize = [906, 804]
+
+# show data in view
+tube_0Display = Show(tube_0, renderView1)
+# trace defaults for the display properties.
+tube_0Display.ColorArrayName = [None, '']
+tube_0Display.GlyphType = 'Arrow'
+tube_0Display.ScalarOpacityUnitDistance = 0.06298890955886752
+
+# reset view to fit data
+renderView1.ResetCamera()
+
+# set scalar coloring
+ColorBy(tube_0Display, ('CELLS', 'p'))
+
+# rescale color and/or opacity maps used to include current data range
+tube_0Display.RescaleTransferFunctionToDataRange(True)
+
+# show color bar/color legend
+tube_0Display.SetScalarBarVisibility(renderView1, True)
+
+# get color transfer function/color map for 'p'
+pLUT = GetColorTransferFunction('p')
+pLUT.RGBPoints = [0.039999999999999994, 0.231373, 0.298039, 0.752941, 0.21999999999999997, 0.865003, 0.865003, 0.865003, 0.3999999999999999, 0.705882, 0.0156863, 0.14902]
+pLUT.ScalarRangeInitialized = 1.0
+
+# get opacity transfer function/opacity map for 'p'
+pPWF = GetOpacityTransferFunction('p')
+pPWF.Points = [0.039999999999999994, 0.0, 0.5, 0.0, 0.3999999999999999, 1.0, 0.5, 0.0]
+pPWF.ScalarRangeInitialized = 1
+
+# change representation type
+tube_0Display.SetRepresentationType('Wireframe')
+
+#### saving camera placements for all active views
+
+# current camera placement for renderView1
+renderView1.CameraPosition = [-1.5246746258669206, -1.1658697596319207, 0.8504380295196987]
+renderView1.CameraFocalPoint = [1.7157778085307534e-17, 8.217522903875317e-17, 0.5]
+renderView1.CameraViewUp = [-0.5973587129868047, 0.7996275200836257, 0.06130576762148048]
+renderView1.CameraParallelScale = 0.5049752469181039
+
+#### uncomment the following to render all views
+#RenderAllViews()
+# alternatively, if you want to write images, you can use SaveScreenshot(...).
+animationScene1.PlayMode = 'Real Time'
+animationScene1.Play()


### PR DESCRIPTION
We would like to validate the generated data. This probe class could help us to dump data at the end of the march, or more precisely, post-loop of a hook.

Besides, a helper script view-p.py is added as well. This is a script to use paraview library to visualize the data in a easier way. It is not related to the probe feature implementation.

The TubeProbe class will be enhanced soon to meet the requirement of issue #128, including:

* dump data of any desired coordination point for each inner and outer loop.
* write the dumped data as a vtu so we could visualize it later by paraview.

The is the first step of issue #128.

# Test This PR

Issue ``./go run`` in ``solvcon/sandbox/gas/tube``

# Expected Result

Specified types of the data will be showed at the end of the whole march, like:

```
*** *** Probe result at Pt/poi#1164(0,0,0)601:
*** *** - rho = 1.000 
*** *** - p = 0.400
```