### PR TITLE
Make the gas probe hook be able to probe norm values of vectors

### DIFF
--- a/sandbox/gas/tube/compare-fixed-location.py
+++ b/sandbox/gas/tube/compare-fixed-location.py
@@ -1,9 +1,46 @@
 #!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2017, Taihsiang Ho <tai271828@gmail.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 """
-
 Compare the npy data dumped by the probe hook of 3D tube example and the data
 of 1D Sod tube analytic solution.
 
+This script creates a plot to compare the associated derived at certain
+location.
+
+Usage:
+    $ ./go run
+    $ ./compare-fixed-location.py
+
+Use the driving script go to generate data and then create the plot with this
+script.
 """
 
 import matplotlib.pyplot as plt
@@ -21,14 +58,17 @@ def load_from_np(filename):
 
     return arr_t, arr_rho, arr_p
 
+
 def load_from_analytic(location, arr_time):
     # load analytic solution data of 1D tube
-    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    # note the coordination of analytic solution is different from the one that
+    # SOLVCON used.
     mesh_1d = (location,)
     analytic_solver = analytic.Solver()
     vals = list()
     for t_step in arr_time:
-        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d,
+                                                                  t=t_step)
         # refer to gas probe.py:Probe::__call__
         vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
         vals.append(vlist)
@@ -39,9 +79,9 @@ def load_from_analytic(location, arr_time):
 
     return arr_aly_t, arr_aly_rho, arr_aly_p
 
+
 def get_deviation(numeric, analytic):
     deviation = list()
-    #import ipdb; ipdb.set_trace()
     for index in xrange(len(numeric)):
         if index == 0:
             deviation.append(numeric[index])
@@ -49,11 +89,20 @@ def get_deviation(numeric, analytic):
             deviation.append(numeric[index] - analytic[index])
     return tuple(deviation)
 
+
 def der_plot(der, deviation=False):
+    """
+
+    :param der: derived data type index, an integer
+    :param deviation: if want to show deviation value? True for yes.
+    :return: None
+    """
     if deviation:
-        f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
+        f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = \
+            plt.subplots(3, 3, sharex='col', sharey='row')
     else:
-        f, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(2, 3, sharex='col', sharey='row')
+        f, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = \
+            plt.subplots(2, 3, sharex='col', sharey='row')
 
     if der == 1:
         f.suptitle("DENSITY")
@@ -82,7 +131,6 @@ def der_plot(der, deviation=False):
         data_dev_3 = get_deviation(data_np_3, data_aly_3)
         ax9.set_title('RIGHT - DEVIATION')
 
-
     ax1.scatter(data_np_1[0], data_np_1[der], s=10, c='b', marker='s')
     ax2.scatter(data_np_2[0], data_np_2[der], s=10, c='b', marker='s')
     ax3.scatter(data_np_3[0], data_np_3[der], s=10, c='b', marker='s')
@@ -95,9 +143,10 @@ def der_plot(der, deviation=False):
         ax8.scatter(data_dev_2[0], data_dev_2[der], s=10, c='g', marker="o")
         ax9.scatter(data_dev_3[0], data_dev_3[der], s=10, c='g', marker="o")
 
-#der_plot(1)
+
+# der_plot(1)
 der_plot(1, deviation=True)
-#der_plot(2)
+# der_plot(2)
 der_plot(2, deviation=True)
 
 plt.show()

--- a/sandbox/gas/tube/compare-fixed-location.py
+++ b/sandbox/gas/tube/compare-fixed-location.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+"""
+
+Compare the npy data dumped by the probe hook of 3D tube example and the data
+of 1D Sod tube analytic solution.
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sodtube1d.solver_analytic as analytic
+
+
+def load_from_np(filename):
+    # load npy data of 3D tube
+    arr = np.load(filename)
+
+    arr_t = arr[:, 0]
+    arr_rho = arr[:, 1]
+    arr_p = arr[:, 2]
+
+    return arr_t, arr_rho, arr_p
+
+def load_from_analytic(location, arr_time):
+    # load analytic solution data of 1D tube
+    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    mesh_1d = (location,)
+    analytic_solver = analytic.Solver()
+    vals = list()
+    for t_step in arr_time:
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        # refer to gas probe.py:Probe::__call__
+        vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
+        vals.append(vlist)
+    arr_aly = np.array(vals, dtype='float64')
+    arr_aly_t = arr_time
+    arr_aly_rho = arr_aly[:, 1]
+    arr_aly_p = arr_aly[:, 2]
+
+    return arr_aly_t, arr_aly_rho, arr_aly_p
+
+def get_deviation(numeric, analytic):
+    deviation = list()
+    #import ipdb; ipdb.set_trace()
+    for index in xrange(len(numeric)):
+        if index == 0:
+            deviation.append(numeric[index])
+        else:
+            deviation.append(numeric[index] - analytic[index])
+    return tuple(deviation)
+
+def der_plot(der, deviation=False):
+    if deviation:
+        f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
+    else:
+        f, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(2, 3, sharex='col', sharey='row')
+
+    if der == 1:
+        f.suptitle("DENSITY")
+    elif der == 2:
+        f.suptitle("PRESSURE")
+
+    data_np_1 = load_from_np("./result/tube_pt_ppank_Left.npy")
+    ax1.set_title('LEFT - SOLVCON')
+    data_np_2 = load_from_np("./result/tube_pt_ppank_Diaphragm.npy")
+    ax2.set_title('DIAPHRAGM - SOLVCON')
+    data_np_3 = load_from_np("./result/tube_pt_ppank_Right.npy")
+    ax3.set_title('RIGHT - SOLVCON')
+
+    data_aly_1 = load_from_analytic(-0.25, data_np_1[0])
+    ax4.set_title('LEFT - ANALYTIC')
+    data_aly_2 = load_from_analytic(0.0, data_np_2[0])
+    ax5.set_title('DIAPHRAGM - ANALYTIC')
+    data_aly_3 = load_from_analytic(0.25, data_np_3[0])
+    ax6.set_title('RIGHT - ANALYTIC')
+
+    if deviation:
+        data_dev_1 = get_deviation(data_np_1, data_aly_1)
+        ax7.set_title('LEFT - DEVIATION')
+        data_dev_2 = get_deviation(data_np_2, data_aly_2)
+        ax8.set_title('DIAPHRAGM - DEVIATION')
+        data_dev_3 = get_deviation(data_np_3, data_aly_3)
+        ax9.set_title('RIGHT - DEVIATION')
+
+
+    ax1.scatter(data_np_1[0], data_np_1[der], s=10, c='b', marker='s')
+    ax2.scatter(data_np_2[0], data_np_2[der], s=10, c='b', marker='s')
+    ax3.scatter(data_np_3[0], data_np_3[der], s=10, c='b', marker='s')
+    ax4.scatter(data_aly_1[0], data_aly_1[der], s=10, c='r', marker="o")
+    ax5.scatter(data_aly_2[0], data_aly_2[der], s=10, c='r', marker="o")
+    ax6.scatter(data_aly_3[0], data_aly_3[der], s=10, c='r', marker="o")
+
+    if deviation:
+        ax7.scatter(data_dev_1[0], data_dev_1[der], s=10, c='g', marker="o")
+        ax8.scatter(data_dev_2[0], data_dev_2[der], s=10, c='g', marker="o")
+        ax9.scatter(data_dev_3[0], data_dev_3[der], s=10, c='g', marker="o")
+
+#der_plot(1)
+der_plot(1, deviation=True)
+#der_plot(2)
+der_plot(2, deviation=True)
+
+plt.show()

--- a/sandbox/gas/tube/compare-fixed-time.py
+++ b/sandbox/gas/tube/compare-fixed-time.py
@@ -1,9 +1,45 @@
 #!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2017, Taihsiang Ho <tai271828@gmail.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 """
-
 Compare the npy data dumped by the probe hook of 3D tube example and the data
 of 1D Sod tube analytic solution.
 
+This script creates a plot to compare the associated derived at certain time.
+
+Usage:
+    $ ./go run
+    $ ./compare-fixed-time.py
+
+Use the driving script go to generate data and then create the plot with this
+script.
 """
 
 import matplotlib.pyplot as plt
@@ -23,15 +59,18 @@ def load_from_np(filename, arr_idx_der):
 
     return arr_t, arr_der
 
+
 def load_from_analytic(location, arr_time, arr_idx_der):
     # load analytic solution data of 1D tube
-    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    # note the coordination of analytic solution is different from
+    # the one that SOLVCON used.
     mesh_1d = (location,)
     analytic_solver = analytic.Solver()
     # parse the analytic data object to be arr type data object
     vals = list()
     for t_step in arr_time:
-        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d,
+                                                                  t=t_step)
         # refer to gas probe.py:Probe::__call__
         vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
         vals.append(vlist)
@@ -43,9 +82,9 @@ def load_from_analytic(location, arr_time, arr_idx_der):
 
     return arr_aly_t, arr_aly_der
 
+
 def get_deviation(numeric, analytic):
     deviation = list()
-    #import ipdb; ipdb.set_trace()
     for index in xrange(len(numeric)):
         if index == 0:
             deviation.append(numeric[index])
@@ -53,15 +92,18 @@ def get_deviation(numeric, analytic):
             deviation.append(numeric[index] - analytic[index])
     return tuple(deviation)
 
+
 def der_plots(step):
     """
-    step: integeter, nth step
+    :param step: integeter, nth step
     """
-    f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
+    f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = \
+        plt.subplots(3, 3, sharex='col', sharey='row')
     t = der_plot(step, 1, f, ax1, ax4, ax7)
     der_plot(step, 2, f, ax2, ax5, ax8)
     der_plot(step, 3, f, ax3, ax6, ax9)
     f.suptitle("SOLVCON 3D CESE vs. 1D ANALYTICAL - " + t + ' sec.')
+
 
 def der_plot(step, der_index, f, ax1, ax2, ax3):
 
@@ -76,11 +118,6 @@ def der_plot(step, der_index, f, ax1, ax2, ax3):
         arr_t, arr_der = load_from_np("./result/" + np_filename, der_index)
         data_der.append(arr_der[step])
 
-    # data_der_analytic = []
-    # for location in locations:
-    #     arr_aly_t, arr_aly_der = load_from_analytic(location, [arr_t[step]], der_index)
-    #     data_der_analytic.append(arr_aly_der[0])
-
     # shift locations so we could input it in analytic coordination.
     locations_aly = []
     for location in locations:
@@ -88,7 +125,8 @@ def der_plot(step, der_index, f, ax1, ax2, ax3):
         locations_aly.append(location_aly)
 
     analytic_solver = analytic.Solver()
-    analytic_solution = analytic_solver.get_analytic_solution(locations_aly, t=arr_t[step])
+    analytic_solution = analytic_solver.get_analytic_solution(locations_aly,
+                                                              t=arr_t[step])
     data_der_analytic = []
     for location_idx in range(len(locations)):
         if der_index == 1:
@@ -114,6 +152,8 @@ def der_plot(step, der_index, f, ax1, ax2, ax3):
 
     return str(arr_t[step])
 
+
+# CHANGE ME: Give the specific time step index number
 der_plots(286)
 
 plt.show()

--- a/sandbox/gas/tube/compare-fixed-time.py
+++ b/sandbox/gas/tube/compare-fixed-time.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""
+
+Compare the npy data dumped by the probe hook of 3D tube example and the data
+of 1D Sod tube analytic solution.
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sodtube1d.solver_analytic as analytic
+
+
+def load_from_np(filename, arr_idx_der):
+    """
+    arr_idx_der 1 for rho and 2 for p
+    """
+    # load npy data of 3D tube
+    arr = np.load(filename)
+
+    arr_t = arr[:, 0]
+    arr_der = arr[:, arr_idx_der]
+
+    return arr_t, arr_der
+
+def load_from_analytic(location, arr_time, arr_idx_der):
+    # load analytic solution data of 1D tube
+    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    mesh_1d = (location,)
+    analytic_solver = analytic.Solver()
+    # parse the analytic data object to be arr type data object
+    vals = list()
+    for t_step in arr_time:
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        # refer to gas probe.py:Probe::__call__
+        vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
+        vals.append(vlist)
+    arr_aly = np.array(vals, dtype='float64')
+    # parsed.
+
+    arr_aly_t = arr_time
+    arr_aly_der = arr_aly[:, arr_idx_der]
+
+    return arr_aly_t, arr_aly_der
+
+def get_deviation(numeric, analytic):
+    deviation = list()
+    #import ipdb; ipdb.set_trace()
+    for index in xrange(len(numeric)):
+        if index == 0:
+            deviation.append(numeric[index])
+        else:
+            deviation.append(numeric[index] - analytic[index])
+    return tuple(deviation)
+
+def der_plots(step):
+    """
+    step: integeter, nth step
+    """
+    f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
+    t = der_plot(step, 1, f, ax1, ax4, ax7)
+    der_plot(step, 2, f, ax2, ax5, ax8)
+    der_plot(step, 3, f, ax3, ax6, ax9)
+    f.suptitle("SOLVCON 3D CESE vs. 1D ANALYTICAL - " + t + ' sec.')
+
+def der_plot(step, der_index, f, ax1, ax2, ax3):
+
+    np_filenames = []
+    locations = []
+    for idx in range(99):
+        np_filenames.append("tube_pt_ppank_" + str(idx) + ".npy")
+        locations.append(idx/100.0)
+
+    data_der = []
+    for np_filename in np_filenames:
+        arr_t, arr_der = load_from_np("./result/" + np_filename, der_index)
+        data_der.append(arr_der[step])
+
+    # data_der_analytic = []
+    # for location in locations:
+    #     arr_aly_t, arr_aly_der = load_from_analytic(location, [arr_t[step]], der_index)
+    #     data_der_analytic.append(arr_aly_der[0])
+
+    # shift locations so we could input it in analytic coordination.
+    locations_aly = []
+    for location in locations:
+        location_aly = location - 0.5
+        locations_aly.append(location_aly)
+
+    analytic_solver = analytic.Solver()
+    analytic_solution = analytic_solver.get_analytic_solution(locations_aly, t=arr_t[step])
+    data_der_analytic = []
+    for location_idx in range(len(locations)):
+        if der_index == 1:
+            title = 'RHO'
+        elif der_index == 2:
+            title = 'M'
+        elif der_index == 3:
+            title = 'PRESSURE'
+        else:
+            title = 'UNKNOWN'
+        data_der_analytic.append(analytic_solution[location_idx][der_index])
+
+    data_der_deviation = []
+    for idx in range(len(data_der)):
+        data_der_deviation.append(data_der[idx] - data_der_analytic[idx])
+
+    ax1.set_title('3D - ' + title)
+    ax1.scatter(locations, data_der, s=10, c='b', marker='s')
+    ax2.set_title('1D - ' + title)
+    ax2.scatter(locations, data_der_analytic, s=10, c='b', marker='8')
+    ax3.set_title('DEVIATION')
+    ax3.scatter(locations, data_der_deviation, s=10, c='b', marker='o')
+
+    return str(arr_t[step])
+
+der_plots(286)
+
+plt.show()

--- a/sandbox/gas/tube/compare-time-animation.py
+++ b/sandbox/gas/tube/compare-time-animation.py
@@ -1,8 +1,46 @@
 #!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2017, Taihsiang Ho <tai271828@gmail.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 """
-
 Compare the npy data dumped by the probe hook of 3D tube example and the data
 of 1D Sod tube analytic solution.
+
+This script creates a video to visual the evolution of the associated derived
+data over time.
+
+Usage:
+    $ ./go run
+    $ ./compare-time-animation.py
+
+Use the driving script go to generate data and then create the video with this
+script.
 
 """
 
@@ -14,6 +52,7 @@ import sodtube1d.solver_analytic as analytic
 # Set up formatting for the movie files
 Writer = animation.writers['ffmpeg']
 writer = Writer(fps=15, metadata=dict(artist='Me'), bitrate=1800)
+
 
 def load_from_np(filename, arr_idx_der):
     """
@@ -27,15 +66,18 @@ def load_from_np(filename, arr_idx_der):
 
     return arr_t, arr_der
 
+
 def load_from_analytic(location, arr_time, arr_idx_der):
     # load analytic solution data of 1D tube
-    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    # note the coordination of analytic solution is different from
+    # the one that SOLVCON used.
     mesh_1d = (location,)
     analytic_solver = analytic.Solver()
     # parse the analytic data object to be arr type data object
     vals = list()
     for t_step in arr_time:
-        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d,
+                                                                  t=t_step)
         # refer to gas probe.py:Probe::__call__
         vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
         vals.append(vlist)
@@ -47,9 +89,9 @@ def load_from_analytic(location, arr_time, arr_idx_der):
 
     return arr_aly_t, arr_aly_der
 
+
 def get_deviation(numeric, analytic):
     deviation = list()
-    #import ipdb; ipdb.set_trace()
     for index in xrange(len(numeric)):
         if index == 0:
             deviation.append(numeric[index])
@@ -57,19 +99,16 @@ def get_deviation(numeric, analytic):
             deviation.append(numeric[index] - analytic[index])
     return tuple(deviation)
 
+
 def der_plots(step):
     """
     step: integeter, nth step
     """
-    #f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
-    #t = der_plot(step, 1, f, ax1, ax4, ax7)
-    #der_plot(step, 2, f, ax2, ax5, ax8)
-    #der_plot(step, 3, f, ax3, ax6, ax9)
-    #f.suptitle("SOLVCON 3D CESE vs. 1D ANALYTICAL - " + t + ' sec.')
     subplot_artists_1 = list(der_plot(step, 1, 1))
     subplot_artists_2 = list(der_plot(step, 2, 2))
     subplot_artists_3 = list(der_plot(step, 3, 3))
     return subplot_artists_1 + subplot_artists_2 + subplot_artists_3
+
 
 def der_plot(step, der_index, base_subplot_idx):
 
@@ -84,11 +123,6 @@ def der_plot(step, der_index, base_subplot_idx):
         arr_t, arr_der = load_from_np("./result/" + np_filename, der_index)
         data_der.append(arr_der[step])
 
-    # data_der_analytic = []
-    # for location in locations:
-    #     arr_aly_t, arr_aly_der = load_from_analytic(location, [arr_t[step]], der_index)
-    #     data_der_analytic.append(arr_aly_der[0])
-
     # shift locations so we could input it in analytic coordination.
     locations_aly = []
     for location in locations:
@@ -96,7 +130,8 @@ def der_plot(step, der_index, base_subplot_idx):
         locations_aly.append(location_aly)
 
     analytic_solver = analytic.Solver()
-    analytic_solution = analytic_solver.get_analytic_solution(locations_aly, t=arr_t[step])
+    analytic_solution = analytic_solver.get_analytic_solution(locations_aly,
+                                                              t=arr_t[step])
     data_der_analytic = []
     for location_idx in range(len(locations)):
         if der_index == 1:
@@ -116,21 +151,28 @@ def der_plot(step, der_index, base_subplot_idx):
     subplot_idx = 330 + base_subplot_idx
     ax1 = plt.subplot(subplot_idx, title='3D - ' + title)
     artist_3d = plt.scatter(locations, data_der, s=10, c='b', marker='s')
-    text1 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax1.transAxes)
+    text1 = plt.text(0.1,
+                     0.08,
+                     "Time: " + str(arr_t[step]), transform=ax1.transAxes)
 
     subplot_idx = 330 + base_subplot_idx + 3
     ax2 = plt.subplot(subplot_idx, title='1D - ' + title)
-    artist_1d = plt.scatter(locations, data_der_analytic, s=10, c='b', marker='8')
-    text2 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax2.transAxes)
+    artist_1d = plt.scatter(locations,
+                            data_der_analytic, s=10, c='b', marker='8')
+    text2 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]),
+                     transform=ax2.transAxes)
 
     subplot_idx = 330 + base_subplot_idx + 6
     ax3 = plt.subplot(subplot_idx, title='DEVIATION - ' + title)
-    artist_dev = plt.scatter(locations, data_der_deviation, s=10, c='b', marker='o')
-    text3 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax3.transAxes)
+    artist_dev = plt.scatter(locations,
+                             data_der_deviation, s=10, c='b', marker='o')
+    text3 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]),
+                     transform=ax3.transAxes)
 
     return artist_3d, artist_1d, artist_dev, text1, text2, text3
 
-my_dpi=96
+
+my_dpi = 96
 fig = plt.figure(figsize=(1600/my_dpi, 1000/my_dpi), dpi=my_dpi)
 frame_seq = []
 
@@ -142,5 +184,5 @@ ani = animation.ArtistAnimation(fig,
                                 interval=25,
                                 repeat_delay=300,
                                 blit=True)
-ani.save('im-170428.mp4', writer=writer)
-#plt.show()
+ani.save('3d-1d-sod-tube.mp4', writer=writer)
+# plt.show()

--- a/sandbox/gas/tube/compare-time-animation.py
+++ b/sandbox/gas/tube/compare-time-animation.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""
+
+Compare the npy data dumped by the probe hook of 3D tube example and the data
+of 1D Sod tube analytic solution.
+
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+import numpy as np
+import sodtube1d.solver_analytic as analytic
+
+# Set up formatting for the movie files
+Writer = animation.writers['ffmpeg']
+writer = Writer(fps=15, metadata=dict(artist='Me'), bitrate=1800)
+
+def load_from_np(filename, arr_idx_der):
+    """
+    arr_idx_der 1 for rho and 2 for p
+    """
+    # load npy data of 3D tube
+    arr = np.load(filename)
+
+    arr_t = arr[:, 0]
+    arr_der = arr[:, arr_idx_der]
+
+    return arr_t, arr_der
+
+def load_from_analytic(location, arr_time, arr_idx_der):
+    # load analytic solution data of 1D tube
+    # note the coordination of analytic solution is different from the one that SOLVCON used.
+    mesh_1d = (location,)
+    analytic_solver = analytic.Solver()
+    # parse the analytic data object to be arr type data object
+    vals = list()
+    for t_step in arr_time:
+        solution_analytic = analytic_solver.get_analytic_solution(mesh_1d, t=t_step)
+        # refer to gas probe.py:Probe::__call__
+        vlist = [t_step, solution_analytic[0][1], solution_analytic[0][3]]
+        vals.append(vlist)
+    arr_aly = np.array(vals, dtype='float64')
+    # parsed.
+
+    arr_aly_t = arr_time
+    arr_aly_der = arr_aly[:, arr_idx_der]
+
+    return arr_aly_t, arr_aly_der
+
+def get_deviation(numeric, analytic):
+    deviation = list()
+    #import ipdb; ipdb.set_trace()
+    for index in xrange(len(numeric)):
+        if index == 0:
+            deviation.append(numeric[index])
+        else:
+            deviation.append(numeric[index] - analytic[index])
+    return tuple(deviation)
+
+def der_plots(step):
+    """
+    step: integeter, nth step
+    """
+    #f, ((ax1, ax2, ax3), (ax4, ax5, ax6), (ax7, ax8, ax9)) = plt.subplots(3, 3, sharex='col', sharey='row')
+    #t = der_plot(step, 1, f, ax1, ax4, ax7)
+    #der_plot(step, 2, f, ax2, ax5, ax8)
+    #der_plot(step, 3, f, ax3, ax6, ax9)
+    #f.suptitle("SOLVCON 3D CESE vs. 1D ANALYTICAL - " + t + ' sec.')
+    subplot_artists_1 = list(der_plot(step, 1, 1))
+    subplot_artists_2 = list(der_plot(step, 2, 2))
+    subplot_artists_3 = list(der_plot(step, 3, 3))
+    return subplot_artists_1 + subplot_artists_2 + subplot_artists_3
+
+def der_plot(step, der_index, base_subplot_idx):
+
+    np_filenames = []
+    locations = []
+    for idx in range(99):
+        np_filenames.append("tube_pt_ppank_" + str(idx) + ".npy")
+        locations.append(idx/100.0)
+
+    data_der = []
+    for np_filename in np_filenames:
+        arr_t, arr_der = load_from_np("./result/" + np_filename, der_index)
+        data_der.append(arr_der[step])
+
+    # data_der_analytic = []
+    # for location in locations:
+    #     arr_aly_t, arr_aly_der = load_from_analytic(location, [arr_t[step]], der_index)
+    #     data_der_analytic.append(arr_aly_der[0])
+
+    # shift locations so we could input it in analytic coordination.
+    locations_aly = []
+    for location in locations:
+        location_aly = location - 0.5
+        locations_aly.append(location_aly)
+
+    analytic_solver = analytic.Solver()
+    analytic_solution = analytic_solver.get_analytic_solution(locations_aly, t=arr_t[step])
+    data_der_analytic = []
+    for location_idx in range(len(locations)):
+        if der_index == 1:
+            title = 'RHO'
+        elif der_index == 2:
+            title = 'V-magnitude'
+        elif der_index == 3:
+            title = 'PRESSURE'
+        else:
+            title = 'UNKNOWN'
+        data_der_analytic.append(analytic_solution[location_idx][der_index])
+
+    data_der_deviation = []
+    for idx in range(len(data_der)):
+        data_der_deviation.append(data_der[idx] - data_der_analytic[idx])
+
+    subplot_idx = 330 + base_subplot_idx
+    ax1 = plt.subplot(subplot_idx, title='3D - ' + title)
+    artist_3d = plt.scatter(locations, data_der, s=10, c='b', marker='s')
+    text1 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax1.transAxes)
+
+    subplot_idx = 330 + base_subplot_idx + 3
+    ax2 = plt.subplot(subplot_idx, title='1D - ' + title)
+    artist_1d = plt.scatter(locations, data_der_analytic, s=10, c='b', marker='8')
+    text2 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax2.transAxes)
+
+    subplot_idx = 330 + base_subplot_idx + 6
+    ax3 = plt.subplot(subplot_idx, title='DEVIATION - ' + title)
+    artist_dev = plt.scatter(locations, data_der_deviation, s=10, c='b', marker='o')
+    text3 = plt.text(0.1, 0.08, "Time: " + str(arr_t[step]), transform=ax3.transAxes)
+
+    return artist_3d, artist_1d, artist_dev, text1, text2, text3
+
+my_dpi=96
+fig = plt.figure(figsize=(1600/my_dpi, 1000/my_dpi), dpi=my_dpi)
+frame_seq = []
+
+for idx_step in range(1, 300):
+    frame_seq.append(der_plots(idx_step))
+
+ani = animation.ArtistAnimation(fig,
+                                frame_seq,
+                                interval=25,
+                                repeat_delay=300,
+                                blit=True)
+ani.save('im-170428.mp4', writer=writer)
+#plt.show()

--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -92,10 +92,13 @@ class TubeProbe(gas.ProbeHook):
         Provide basic information to the probe hook.
         """
         # define where to probe
-        poi = ('poi', 0.0, 0.0, 0.0)
+        pois = []
+        for z_axis in range(99):
+            poi = (str(z_axis), 0.0, 0.0, z_axis/100.0)
+            pois.append(poi)
         # provide coordination and spec list information to the probe hook.
-        kw['coords'] = (poi,)
-        kw['speclst'] = ['rho', 'p']
+        kw['coords'] = pois
+        kw['speclst'] = ['rho', 'v', 'p']
         super(TubeProbe, self).__init__(cse, **kw)
 
     def postloop(self):
@@ -103,9 +106,10 @@ class TubeProbe(gas.ProbeHook):
         Dump the probe data in the end.
         """
         super(TubeProbe, self).postloop()
-        rho, p = self.points[0].vals[-1][1:]
+        rho, v, p = self.points[0].vals[-1][1:]
         self.info('Probe result at %s:\n' % self.points[0])
         self.info('- rho = %.3f \n' % rho)
+        self.info('- v = %.3f \n' % v)
         self.info('- p = %.3f \n' % p)
 
 
@@ -262,7 +266,7 @@ def tube(casename, **kw):
         casename,
         # Arguments to the base configuration.
         gamma=1.4,
-        ssteps=200, psteps=4, edgelength=0.02,
+        ssteps=8, psteps=4, edgelength=0.02,
         rho1=1.0, p1=1.0,
         rho2=0.125, p2=0.1,
         # Arguments to GasCase.

--- a/solvcon/parcel/gas/probe.py
+++ b/solvcon/parcel/gas/probe.py
@@ -74,7 +74,10 @@ class Probe(object):
                     arr = svr.sol[:,spec]
             if arr is None:
                 raise IndexError('spec %s incorrect'%str(spec))
-            vlist.append(arr[ngstcell+self.pcl])
+            target_data = arr[ngstcell + self.pcl]
+            if isinstance(target_data, np.ndarray):
+                target_data = np.linalg.norm(target_data, ord=2)
+            vlist.append(target_data)
         self.vals.append(vlist)
 
 


### PR DESCRIPTION
The original ``solvcon/parcel/gas/probe.py`` could only store scalar values of derived data. If [the returned array of derived data object](https://github.com/solvcon/solvcon/blob/master/solvcon/parcel/gas/probe.py#L68)  is a vector, it will conflict with [the saving action of float64]( https://github.com/solvcon/solvcon/blob/master/solvcon/parcel/gas/probe.py#L153).

The commit https://github.com/solvcon/solvcon/commit/d793e4235f59b7321147c0fb5f353bcebbdc5651 get s the 2-order norm of a vector prior to the saving action. Thus, we could probe the magnitude of velocity for example.

The rest of the commits includes the driving script to probe the magnitude of velocity, and the helper scripts to analyze and visualize the output data over paraview. [This](https://www.dropbox.com/s/ptjv58b78h7xoc8/3d-1d-sod-tube-170508.mp4?dl=0) is an animation example of the driving script output being compared with the result of the 1D Sod tube.

## How to Test This PR

```
$ ./go run
$ ./compare-time-animation.py
```

Then you should get a video file in MP4.