### PR TITLE
Fix Travis-CI failure: hide wrapper visibility for gcc.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,8 @@ def main():
         else:
             ext_modules = cythonize(ext_modules)
 
+    with open('README.rst') as fobj:
+        long_description = ''.join(fobj.read())
     setup(
         name='SOLVCON',
         maintainer='Yung-Yu Chen',
@@ -279,7 +281,7 @@ def main():
         maintainer_email='yyc@solvcon.net',
         author_email='yyc@solvcon.net',
         description='Solvers of Conservation Laws',
-        long_description=''.join(open('README.rst').read()),
+        long_description=long_description,
         license='BSD',
         url='http://solvcon.net/',
         download_url='https://github.com/solvcon/solvcon/releases',

--- a/solvcon/march.cpp
+++ b/solvcon/march.cpp
@@ -99,10 +99,19 @@ private:
 
 }; /* end class Table */
 
+#ifdef __GNUG__
+#  define WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
+#else
+#  define WRAPPER_VISIBILITY
+#endif
+
 /**
  * Helper class for pybind11 class wrappers.
  */
-template< class Wrapper, class Wrapped, class Holder = std::unique_ptr<Wrapped>> class WrapBase {
+template< class Wrapper, class Wrapped, class Holder = std::unique_ptr<Wrapped>>
+class
+WRAPPER_VISIBILITY
+WrapBase {
 
 public:
 
@@ -146,7 +155,11 @@ protected:
 
 }; /* end class WrapBase */
 
-class WrapLookupTableCore : public WrapBase< WrapLookupTableCore, LookupTableCore > {
+class
+WRAPPER_VISIBILITY
+WrapLookupTableCore
+  : public WrapBase< WrapLookupTableCore, LookupTableCore >
+{
 
     friend base_type;
 
@@ -278,7 +291,11 @@ class WrapLookupTableCore : public WrapBase< WrapLookupTableCore, LookupTableCor
 
 }; /* end class WrapLookupTableCore */
 
-class WrapBoundaryData : public WrapBase< WrapBoundaryData, BoundaryData > {
+class
+WRAPPER_VISIBILITY
+WrapBoundaryData
+  : public WrapBase< WrapBoundaryData, BoundaryData >
+{
 
     friend base_type;
 
@@ -410,7 +427,9 @@ public:
 }; /* end class UnstructuredBlockConstructorAgent */ } /* end namespace march */
 
 template< size_t NDIM >
-class WrapUnstructuredBlock
+class
+WRAPPER_VISIBILITY
+WrapUnstructuredBlock
   : public WrapBase< WrapUnstructuredBlock<NDIM>, UnstructuredBlock<NDIM>, std::shared_ptr<UnstructuredBlock<NDIM>> >
 {
 


### PR DESCRIPTION
This is the build failure: https://travis-ci.org/yungyuc/solvcon/builds/237473710 .  This is why we need to take care of the symbol visibility: https://github.com/pybind/pybind11/blob/master/include/pybind11/detail/common.h#L24 .  pybind11 hid the visibility two months ago: https://github.com/pybind/pybind11/commit/a859dd67a29372e478ad862d8d2979930471532e .

In addition to the build faillure, fix a resource warning in setup.py.