### PR TITLE
Upgrade pybind11 placement new.

### DIFF
--- a/libmarch/include/march/gas/Solver_decl.hpp
+++ b/libmarch/include/march/gas/Solver_decl.hpp
@@ -21,8 +21,6 @@ namespace gas {
 
 template< size_t NDIM > class Quantity;
 
-class SolverConstructorAgent; /* backdoor for pybind11 */
-
 template< size_t NDIM >
 class Solver
   : public std::enable_shared_from_this<Solver<NDIM>>
@@ -75,7 +73,6 @@ public:
     private:
         ctor_passkey() = default;
         friend Solver<NDIM>;
-        friend SolverConstructorAgent; /* backdoor for pybind11 */
     };
 
     Solver(const ctor_passkey &, const std::shared_ptr<block_type> & block);

--- a/libmarch/include/march/mesh/UnstructuredBlock/class.hpp
+++ b/libmarch/include/march/mesh/UnstructuredBlock/class.hpp
@@ -23,8 +23,6 @@ namespace march {
 
 static constexpr size_t NCLTYPE=8;
 
-class UnstructuredBlockConstructorAgent; /* should only be defined once in Python wrapping code */
-
 /**
  * Unstructured mesh of mixed-type elements, optimized for reading.
  *
@@ -145,7 +143,6 @@ public:
     private:
         ctor_passkey() = default;
         friend UnstructuredBlock<NDIM>;
-        friend UnstructuredBlockConstructorAgent; /* backdoor for pybind11 */
     };
 
     UnstructuredBlock(


### PR DESCRIPTION
In the past pybind11 forced an storage for constructor and unpickler, which is unfriendly to C++ private constructors.  To work around it libmarch used friendship.  Now pybind11 reworked a new constructor and pickling support: http://pybind11.readthedocs.io/en/stable/upgrade.html#new-api-for-defining-custom-constructors-and-pickling-functions .  The friendship is no longer needed.