### PR TITLE
Fix issue caused by netcdf4-python upgrade (ref issue #204)

### DIFF
--- a/solvcon/io/netcdf.py
+++ b/solvcon/io/netcdf.py
@@ -132,6 +132,8 @@ class NetCDF(object):
         # Load variable.
         var = self.root_group[name]
         arr = var[...]
+        if isinstance(arr, np.ma.MaskedArray): # issue #204
+            arr = arr.filled()
         assert isinstance(arr, np.ndarray)
         if len(shape) > 2:
             raise IndexError('array should have no more than two dimension')


### PR DESCRIPTION
Root cause:

In 1.4.0 release, netcdf4-python changes to [always return numpy.ma.MaskedArray](https://github.com/Unidata/netcdf4-python/blob/master/Changelog#L28).  solvcon.io.netcdf.NetCDF.get_lines() relies on the fill_value to parse.  The change makes get_lines() to crash.

Resolution:

Fill the invalid value and get an ndnarray back for parsing when netcdf gives a MaskedArray.