### PR TITLE
Add Singularity recipe file to build Singularity-based SOLVCON image

### DIFF
--- a/contrib/singularity/README.rst
+++ b/contrib/singularity/README.rst
@@ -29,10 +29,12 @@ Use the container by
 
   $ singularity shell ./<name-of-the-image>.img
 
-You could find the built SOLVCON is under `/opt/solvcon/dist/SOLVCON-<Version Number>`.
-
 Activate the runtime by
 
-  [container] $ source contrib/singularity/activate.sh
+  [container] :SOLVCON-SRC-ROOT> source contrib/singularity/activate.sh
 
-So far the feature of single process run on the local container works only.
+You could find the built SOLVCON is under `/opt/solvcon/dist/SOLVCON-<Version Number>`. Go there and run some jobs
+
+  [container] :/opt/solvcon/dist/SOLVCON-0.1.4+> nosetests --with-doctest
+
+So far the feature of parallel mode does not work in the singularity container.

--- a/contrib/singularity/README.rst
+++ b/contrib/singularity/README.rst
@@ -1,0 +1,38 @@
+SOLVCON Singularity-based image build file.
+
+Pre-requisite
+=============
+
+Install `Singularity <http://singularity.lbl.gov/>`_.
+
+Create a file `host-username.txt` by
+
+  $ whoami > /tmp/host-username.txt
+
+This is a trick for you to touch the SOLVCON folder in the container later after building the singularity image.
+
+This instruction is verified by running on Ubuntu Xenial.
+
+Build
+=====
+
+Build the image by
+
+  $ sudo singularity build ./<name-of-the-image>.img ./Singularity
+
+In this case, `sudo` is necessary to execute post actions of the build process.
+
+Use the Container
+=================
+
+Use the container by
+
+  $ singularity shell ./<name-of-the-image>.img
+
+You could find the built SOLVCON is under `/opt/solvcon/dist/SOLVCON-<Version Number>`.
+
+Activate the runtime by
+
+  [container] $ source contrib/singularity/activate.sh
+
+So far the feature of single process run on the local container works only.

--- a/contrib/singularity/Singularity
+++ b/contrib/singularity/Singularity
@@ -1,0 +1,72 @@
+BootStrap: debootstrap
+OSVersion: xenial
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
+
+
+%runscript
+    echo "Welcome to SOLVCON singularity instance."
+
+%files
+    /tmp/host-username.txt /host-username.txt
+
+%post
+    echo "Prepare to build SOLVCON in singularity instance..."
+    sed -i 's/$/ universe/' /etc/apt/sources.list
+    apt-get update
+    # general tools
+    apt-get install vim git -y
+    # used for miniconda extraction
+    apt-get install bzip2
+    # SOLVCON build tools
+    apt-get install openssh-client openssh-server liblapack-pic liblapack-dev -y
+    apt-get install build-essential unzip -y
+    # it currently works in the root path
+    echo "Working location: " `pwd`
+    # it is /root
+    echo $HOME
+    apt-get clean
+
+    # I want solvcon source code and folder is managed by the same
+    # user who triggers the container execution
+    export TARGET_USERNAME=`cat /host-username.txt`
+    adduser --no-create-home --disabled-password --gecos "" $TARGET_USERNAME
+
+    export SOLVCON_BUILD_DIR=/opt
+    cd $SOLVCON_BUILD_DIR/
+    git clone https://github.com/solvcon/solvcon.git $SOLVCON_BUILD_DIR/solvcon
+
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    ls ./
+    ls $SOLVCON_BUILD_DIR/
+    bash miniconda.sh -b -p $SOLVCON_BUILD_DIR/miniconda
+    export PATH="$SOLVCON_BUILD_DIR/miniconda/bin:$PATH"
+    conda update -q conda
+    which python; python --version
+    #which $CXX; $CXX --version
+    #which $CC; $CC --version
+
+    $SOLVCON_BUILD_DIR/solvcon/contrib/devenv/create.sh
+    bash -c "source $SOLVCON_BUILD_DIR/solvcon/build/env/start"
+    $SOLVCON_BUILD_DIR/solvcon/contrib/conda.sh
+    $SOLVCON_BUILD_DIR/solvcon/contrib/build-pybind11-in-conda.sh
+    #$SOLVCON_BUILD_DIR/solvcon/contrib/release.sh
+    SCVER=`cd $SOLVCON_BUILD_DIR/solvcon; python -c 'import sys; import solvcon; sys.stdout.write("%s\\n" % solvcon.__version__)'`
+
+    # package source distribution file.
+    cd $SOLVCON_BUILD_DIR/solvcon
+    ls
+    rm -rf dist/SOLVCON-${SCVER}*
+    python setup.py clean
+    python setup.py sdist
+
+    # unpack the distribution file.
+    cd dist
+    rm -rf SOLVCON-${SCVER}/
+    tar xfz SOLVCON-${SCVER}.tar.gz
+    cd SOLVCON-${SCVER}
+    ## build.
+    python setup.py build_ext --inplace
+    nosetests --with-doctest
+
+    # so the normal user could write SOLVCON folder
+    chown $TARGET_USERNAME -R $SOLVCON_BUILD_DIR/*

--- a/contrib/singularity/activate.sh
+++ b/contrib/singularity/activate.sh
@@ -1,0 +1,3 @@
+export SOLVCON_BUILD_DIR=/opt
+export PATH="$SOLVCON_BUILD_DIR/miniconda/bin:$PATH"
+source $SOLVCON_BUILD_DIR/solvcon/build/env/start


### PR DESCRIPTION
This is the first commit to have the singularity recipe to build a singularity-based SOLVCON image. The instruction of how to build and test has been written in the README.

This singularity image is based on Ubuntu Xenial.