### PR TITLE
Decouple libmarch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,14 @@ solvcon:opt:
   artifacts:
     untracked: true
 
+solvcon:release:
+  stage: build
+  script:
+    - env SC_PURE_PYTHON=1 contrib/release.sh
+  artifacts:
+    paths:
+      - dist/SOLVCON*.tar.gz
+
 libmarch:opt:gtest:
   dependencies:
     - libmarch:opt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,33 +1,79 @@
 image: solvcon/solvcon_build:latest
 
+stages:
+  - build
+  - test
+
 before_script:
-- which g++; g++ --version
-- which python3; python3 --version
+  - which g++; g++ --version
+  - which python3; python3 --version
 
-libmarch_opt_build:
+libmarch:opt:
+  stage: build
   script:
-  - mkdir -p ${CI_PROJECT_DIR}/libmarch/build/rel
-  - cd ${CI_PROJECT_DIR}/libmarch/build/rel
-  - cmake -DPYTHON_EXECUTABLE:FILEPATH=`which python3`
-    -DCMAKE_BUILD_TYPE=Release
-    -DTESTFILTER="*"
-    ${CI_PROJECT_DIR}/libmarch
-  - cd ${CI_PROJECT_DIR}/libmarch
-  - make -C build/rel run_gtest VERBOSE=1
+    - mkdir -p ${CI_PROJECT_DIR}/libmarch/build/opt
+    - cd ${CI_PROJECT_DIR}/libmarch/build/opt
+    - cmake -DPYTHON_EXECUTABLE:FILEPATH=`which python3`
+      -DCMAKE_BUILD_TYPE=Release
+      -DTESTFILTER="*"
+      ${CI_PROJECT_DIR}/libmarch
+    - make -C ${CI_PROJECT_DIR}/libmarch/build/opt VERBOSE=1
+  artifacts:
+    untracked: true
 
-libmarch_dbg_build:
+libmarch:dbg:
+  stage: build
   script:
-  - mkdir -p ${CI_PROJECT_DIR}/libmarch/build/dbg
-  - cd ${CI_PROJECT_DIR}/libmarch/build/dbg
-  - cmake -DPYTHON_EXECUTABLE:FILEPATH=`which python3`
-    -DCMAKE_BUILD_TYPE=Debug
-    -DTESTFILTER="*"
-    ${CI_PROJECT_DIR}/libmarch
-  - cd ${CI_PROJECT_DIR}/libmarch
-  - make -C build/dbg run_gtest VERBOSE=1
+    - mkdir -p ${CI_PROJECT_DIR}/libmarch/build/dbg
+    - cd ${CI_PROJECT_DIR}/libmarch/build/dbg
+    - cmake -DPYTHON_EXECUTABLE:FILEPATH=`which python3`
+      -DCMAKE_BUILD_TYPE=Debug
+      -DTESTFILTER="*"
+      ${CI_PROJECT_DIR}/libmarch
+    - make -C ${CI_PROJECT_DIR}/libmarch/build/dbg VERBOSE=1
+  artifacts:
+    untracked: true
 
-solvcon_opt_build:
+solvcon:opt:
+  stage: build
   script:
-  - make VERBOSE=1
-  - python3 setup.py build_ext --inplace
-  - nosetests3 --with-doctest
+    - make VERBOSE=1
+    - python3 setup.py build_ext --inplace
+    - nosetests3 --with-doctest
+  artifacts:
+    untracked: true
+
+libmarch:opt:gtest:
+  dependencies:
+    - libmarch:opt
+  stage: test
+  script:
+    - make -C ${CI_PROJECT_DIR}/libmarch/build/opt run_gtest VERBOSE=1
+
+libmarch:dbg:gtest:
+  dependencies:
+    - libmarch:dbg
+  stage: test
+  script:
+    - make -C ${CI_PROJECT_DIR}/libmarch/build/dbg run_gtest VERBOSE=1
+
+solvcon:opt:unittest:
+  dependencies:
+    - solvcon:opt
+  stage: test
+  script:
+    - nosetests3 --with-doctest -v
+
+solvcon:opt:test:gasplus:
+  dependencies:
+    - solvcon:opt
+  stage: test
+  script:
+    - nosetests3 ftests/gasplus/* -v
+
+solvcon:opt:test:parallel:
+  dependencies:
+    - solvcon:opt
+  stage: test
+  script:
+    - nosetests3 ftests/parallel/* -v

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,3 +25,9 @@ libmarch_dbg_build:
     ${CI_PROJECT_DIR}/libmarch
   - cd ${CI_PROJECT_DIR}/libmarch
   - make -C build/dbg run_gtest VERBOSE=1
+
+solvcon_opt_build:
+  script:
+  - make VERBOSE=1
+  - python3 setup.py build_ext --inplace
+  - nosetests3 --with-doctest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,8 +38,6 @@ solvcon:opt:
   stage: build
   script:
     - make VERBOSE=1
-    - python3 setup.py build_ext --inplace
-    - nosetests3 --with-doctest
   artifacts:
     untracked: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
+language: cpp
+dist: trusty
+
 cache:
   directory:
   - $HOME/miniconda
-
-# If using C++11/14 see http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/
-addons:
-  apt:
-    packages:
-      - openssh-client
-      - openssh-server
-      - liblapack-pic
-      - liblapack-dev
 
 notifications:
   slack:
@@ -35,61 +29,91 @@ matrix:
   include:
     - os: linux
       sudo: required
-      dist: trusty
-      language: cpp
+      services: docker
+      env: RUNMODE=docker
+    - os: linux
+      sudo: required
       compiler: gcc
+      env: RUNMODE=travis
+      addons:
+        # If using C++11/14 see http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/
+        apt:
+          packages: [ openssh-client, openssh-server, liblapack-pic, liblapack-dev ]
     - os: osx
       #osx_image: xcode7.3
-      language: cpp
       compiler: clang
+      env: RUNMODE=travis
 
 before_install:
-  # Configure ssh
-  - ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
-  - chmod 700 ~/.ssh/
-  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-  - chmod 600 ~/.ssh/authorized_keys
-  - ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
-  - ssh-keyscan -t rsa 127.0.0.1 >> ~/.ssh/known_hosts
-  - chmod 600 ~/.ssh/known_hosts
-  - ls -al ~/.ssh/
-  - ssh localhost ls
-  - ssh 127.0.0.1 ls
-  # Install minimal conda
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+  - |
+    if [[ "$RUNMODE" == "docker" ]] ; then
+      # Configure docker
+      DOCKER=solvcon/solvcon_build
+      docker pull $DOCKER
+
+      containerid=$(docker run --detach --tty \
+        --volume="${TRAVIS_BUILD_DIR}":${TRAVIS_BUILD_DIR} \
+        --workdir=${TRAVIS_BUILD_DIR} \
+        $DOCKER)
+
+      SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      # Configure ssh
+      ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+      chmod 700 ~/.ssh/
+      cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+      chmod 600 ~/.ssh/authorized_keys
+      ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
+      ssh-keyscan -t rsa 127.0.0.1 >> ~/.ssh/known_hosts
+      chmod 600 ~/.ssh/known_hosts
+      ls -al ~/.ssh/
+      ssh localhost ls
+      ssh 127.0.0.1 ls
+
+      SCRIPT_RUN_PREFIX=
     fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - which python; python --version
-  - conda info -a
-  # Debug information of compiler
-  - which $CXX; $CXX --version
-  - which $CC; $CC --version
 
 install:
-  - ${TRAVIS_BUILD_DIR}/contrib/devenv/create.sh
-  - source ${TRAVIS_BUILD_DIR}/build/env/start
-  - ${TRAVIS_BUILD_DIR}/contrib/conda.sh
-  - ${TRAVIS_BUILD_DIR}/contrib/build-pybind11-in-conda.sh
-  - which python; python --version
-  - conda info -a
-  - set | grep SC
-  - set | grep CONDA
+  - |
+    if [[ "$RUNMODE" != "docker" ]] ; then
+      # Install minimal conda
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      fi
+      bash miniconda.sh -b -p $HOME/miniconda
+      export PATH="$HOME/miniconda/bin:$PATH"
+      hash -r
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+    fi
+  - |
+    if [[ "$RUNMODE" != "docker" ]] ; then
+      # Install conda packages
+      ${TRAVIS_BUILD_DIR}/contrib/devenv/create.sh
+      source ${TRAVIS_BUILD_DIR}/build/env/start
+      ${TRAVIS_BUILD_DIR}/contrib/conda.sh
+      ${TRAVIS_BUILD_DIR}/contrib/build-pybind11-in-conda.sh
+      # Debugging information
+      conda info -a
+    fi
 
 script:
-  # C++ debug build
-  - mkdir -p ${TRAVIS_BUILD_DIR}/build/debug
-  - cd ${TRAVIS_BUILD_DIR}/build/debug
-  - cmake -DPYTHON_EXECUTABLE:FILEPATH=`which python` -Dpybind11_DIR=${CONDA_PREFIX}/share/cmake/pybind11 -DTESTFILTER="*" -DCMAKE_BUILD_TYPE=Debug ${TRAVIS_BUILD_DIR}
-  - cd ${TRAVIS_BUILD_DIR}
-  - make -C build/debug run_gtest VERBOSE=1
-  # Package
-  - cd ${TRAVIS_BUILD_DIR}
-  - contrib/release.sh
+  # Debugging information
+  - |
+    $SCRIPT_RUN_PREFIX which python3
+    $SCRIPT_RUN_PREFIX python3 --version
+    $SCRIPT_RUN_PREFIX which $CXX
+    $SCRIPT_RUN_PREFIX $CXX --version
+    $SCRIPT_RUN_PREFIX which $CC
+    $SCRIPT_RUN_PREFIX $CC --version
+  - $SCRIPT_RUN_PREFIX make
+  - $SCRIPT_RUN_PREFIX contrib/release.sh
+
+after_script:
+  - |
+    if [[ "$RUNMODE" == "docker" ]] ; then
+      docker stop "$containerid"
+      docker rm "$containerid"
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,8 +108,7 @@ script:
     $SCRIPT_RUN_PREFIX $CXX --version
     $SCRIPT_RUN_PREFIX which $CC
     $SCRIPT_RUN_PREFIX $CC --version
-  - $SCRIPT_RUN_PREFIX make
-  - $SCRIPT_RUN_PREFIX contrib/release.sh
+  - $SCRIPT_RUN_PREFIX env SC_PURE_PYTHON=1 contrib/release.sh
 
 after_script:
   - |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CMakeLists.txt
+include Makefile
 include MANIFEST.in
 include requirements.txt
 include README.rst HISTORY.rst CREDITS.rst COPYING

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+SHELL = /bin/bash
+LIBMARCH_PATH ?= libmarch
+BUILD_DIR_NAME ?= opt_from_solvcon
+
+CMAKE_BUILD_TYPE ?= Release
+CMAKE_PASSTHROUGH ?=
+VERBOSE ?=
+
+build_dir = ${LIBMARCH_PATH}/build/${BUILD_DIR_NAME}
+
+.PHONY: default
+default: build
+
+${build_dir}/Makefile:
+	mkdir -p ${build_dir}
+	cd ${build_dir} ; \
+		cmake ../.. \
+			-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+			-DPYTHON_EXECUTABLE:FILEPATH=`which python3` \
+			-DMARCH_TEST=OFF \
+			-DMARCH_DESTINATION=$(realpath .) \
+			${CMAKE_PASSTHROUGH}
+
+.PHONY: cmake
+cmake: ${build_dir}/Makefile
+
+.PHONY: clean_cmake
+clean_cmake:
+	rm -rf ${build_dir}
+
+.PHONY: build
+build: ${build_dir}/Makefile
+	make -C ${build_dir} install VERBOSE=${VERBOSE}
+
+.PHONY: clean_build
+clean_build:
+	rm -rf libmarch.*.so
+
+.PHONY: clean
+clean: clean_build clean_cmake

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL = /bin/bash
+PYTHON = $(shell which python3)
 LIBMARCH_PATH ?= libmarch
 BUILD_DIR_NAME ?= opt_from_solvcon
 
@@ -9,14 +10,17 @@ VERBOSE ?=
 build_dir = ${LIBMARCH_PATH}/build/${BUILD_DIR_NAME}
 
 .PHONY: default
-default: build
+default: everything
+
+.PHONY: everything
+everything: build legacy
 
 ${build_dir}/Makefile:
 	mkdir -p ${build_dir}
 	cd ${build_dir} ; \
 		cmake ../.. \
 			-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-			-DPYTHON_EXECUTABLE:FILEPATH=`which python3` \
+			-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON} \
 			-DMARCH_TEST=OFF \
 			-DMARCH_DESTINATION=$(realpath .) \
 			${CMAKE_PASSTHROUGH}
@@ -36,5 +40,16 @@ build: ${build_dir}/Makefile
 clean_build:
 	rm -rf libmarch.*.so
 
+.PHONY: clean_current
+clean_current: clean_build clean_cmake
+
+.PHONY: legacy
+legacy:
+	${PYTHON} setup.py build_ext --inplace
+
+.PHONY: clean_legacy
+clean_legacy:
+	${PYTHON} setup.py clean
+
 .PHONY: clean
-clean: clean_build clean_cmake
+clean: clean_legacy clean_current

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-SCVER=`python3 -c 'import sys; import solvcon; sys.stdout.write("%s\\n" % solvcon.__version__)'`
+SCVER=$(python3 -c 'import sys; import solvcon; sys.stdout.write("%s"%solvcon.__version__)')
 
 # package source distribution file.
 rm -rf dist/SOLVCON-${SCVER}*

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,13 +1,17 @@
 #!/bin/bash -x
 
-SCVER=`python -c 'import sys; import solvcon; sys.stdout.write("%s\\n" % solvcon.__version__)'`
+SCVER=`python3 -c 'import sys; import solvcon; sys.stdout.write("%s\\n" % solvcon.__version__)'`
 
 # package source distribution file.
 rm -rf dist/SOLVCON-${SCVER}*
-python setup.py clean
-python setup.py sdist
+python3 setup.py clean
+python3 setup.py sdist
 
 # unpack the distribution file.
+if [[ ! -d "dist" ]] ; then
+  echo "fatal error: dist doesn't exist"
+  exit 1
+fi
 cd dist
 rm -rf SOLVCON-${SCVER}/
 tar xfz SOLVCON-${SCVER}.tar.gz
@@ -16,21 +20,17 @@ cd SOLVCON-${SCVER}
 retval=0
 
 # build.
-python setup.py build_ext --inplace
+make
 lret=$?; if [[ $lret != 0 ]] ; then retval=$lret ; fi
 
-# test.
-PYTHONPATH=`pwd`
-nosetests --with-doctest ; lret=$?
-if [[ $lret != 0 ]] ; then retval=$lret ; fi
-nosetests ftests/gasplus/* -v ; lret=$?
-if [[ $lret != 0 ]] ; then retval=$lret ; fi
-nosetests ftests/parallel/* ; lret=$?
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  echo "As of 2017/12/6, travis osx image randomly fails tests related to rpc \
-with ssh.  Disregard the error report for now."
+# unit test.
+if [[ -n `which nosetests3` ]] ; then
+  NOSETESTS=nosetests3
 else
-  if [[ $lret != 0 ]] ; then retval=$lret ; fi
+  NOSETESTS=nosetests
 fi
+PYTHONPATH=`pwd`
+$NOSETESTS --with-doctest ; lret=$?
+if [[ $lret != 0 ]] ; then retval=$lret ; fi
 
 exit $retval

--- a/libmarch/CMakeLists.txt
+++ b/libmarch/CMakeLists.txt
@@ -18,7 +18,8 @@ include(FindPythonAnaconda)
 
 option(MARCH_RELAX_ERROR "Relax compiler error" OFF)
 option(MARCH_NO_DEPRECATE_WARNING "Turn off deprecation warning" OFF)
-option(SOLVCON_ROOT "SOLVCON root path" OFF)
+option(MARCH_DESTINATION "SOLVCON root path" OFF)
+option(MARCH_TEST "Build libmarch test cases" ON)
 
 find_package(SCOTCH)
 
@@ -41,8 +42,8 @@ if(MARCH_RELAX_ERROR)
     set(MARCH_WARNOPT "${MARCH_WARNOPT} -Wno-error=unused-variable")
 endif()
 
-if(NOT SOLVCON_ROOT)
-    set(SOLVCON_ROOT ${CMAKE_INSTALL_PREFIX})
+if(NOT MARCH_DESTINATION)
+    set(MARCH_DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC ${MARCH_WARNOPT}")
@@ -102,6 +103,8 @@ string(REPLACE "include/" "${CMAKE_CURRENT_SOURCE_DIR}/include/"
        MARCH_HEADERS "${MARCH_HEADERS}")
 
 add_subdirectory(src)
-add_subdirectory(tests)
+if (MARCH_TEST)
+    add_subdirectory(tests)
+endif()
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4:

--- a/libmarch/src/python/CMakeLists.txt
+++ b/libmarch/src/python/CMakeLists.txt
@@ -12,8 +12,8 @@ set(MARCH_PY_SOURCES
     march.cpp
     march_gas.cpp
 )
-pybind11_add_module(march ${MARCH_PY_SOURCES})
-target_link_libraries(march PRIVATE ${SCOTCH_LIBRARIES})
-install(TARGETS march DESTINATION ${SOLVCON_ROOT})
+pybind11_add_module(libmarch ${MARCH_PY_SOURCES})
+target_link_libraries(libmarch PRIVATE ${SCOTCH_LIBRARIES})
+install(TARGETS libmarch DESTINATION ${MARCH_DESTINATION})
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4:

--- a/libmarch/src/python/march.cpp
+++ b/libmarch/src/python/march.cpp
@@ -57,7 +57,7 @@ PyObject * ModuleInitializer::initialize_march(pybind11::module & mod) {
 
 } /* end namespace march */
 
-PYBIND11_MODULE(march, mod) {
+PYBIND11_MODULE(libmarch, mod) {
     ::march::python::ModuleInitializer::get_instance().initialize(mod);
 }
 

--- a/setup.py
+++ b/setup.py
@@ -124,10 +124,6 @@ def make_cython_extension(
     )
 
 
-class CmakeExtension(Extension):
-    pass
-
-
 class my_build_ext(np_build_ext.build_ext):
 
     def _copy_cmake_extension(self, ext):
@@ -160,10 +156,7 @@ class my_build_ext(np_build_ext.build_ext):
     def build_extension(self, ext):
         ''' Copies the already-compiled pyd
         '''
-        if isinstance(ext, CmakeExtension):
-            return self._copy_cmake_extension(ext)
-        else: # fallback
-            return np_build_ext.build_ext.build_extension(self, ext)
+        return np_build_ext.build_ext.build_extension(self, ext)
 
 
 def main():
@@ -256,7 +249,6 @@ def main():
                 '-Wno-unknown-pragmas',
             ],
         ),
-        #CmakeExtension('solvcon.march', ['CMakeLists.txt']),
     ]
 
     # remove files when cleaning.
@@ -284,43 +276,6 @@ def main():
             ext_modules = list()
         else:
             ext_modules = cythonize(ext_modules)
-
-    # call cmake.
-    if hasattr(sys, 'gettotalrefcount'):
-        cmake_build_dir = 'build/march_dbg'
-        cmake_build_type = 'Debug'
-    else:
-        cmake_build_dir = 'build/march_rel'
-        cmake_build_type = 'Release'
-    if cidx > sidx:
-        cmds = ['rm -rf %s' % cmake_build_dir,
-                'rm -f solvcon/march*.so']
-        sys.stdout.write('\n'.join(['[for cmake] '+cmd for cmd in cmds]))
-        sys.stdout.write('\n')
-        os.system(' ; '.join(cmds))
-    else:
-        if '--inplace' not in sys.argv:
-            sys.stdout.write(
-                "cmake extension can only be built inplace; "
-                "add --inplace argument\n")
-        if "CONDA_PREFIX" in os.environ:
-            conda_evars = "LIBRARY_PATH=%s" % os.path.join(
-                os.environ["CONDA_PREFIX"], "lib")
-        else:
-            conda_evars = ""
-        cmake_cmds = [
-            'env %s cmake' % conda_evars,
-            os.environ.get('CMAKE_PASSTHROUGH', ''),
-            '-DPYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable,
-            '-DCMAKE_BUILD_TYPE=%s ../..' % cmake_build_type,
-        ]
-        cmds = ['mkdir -p %s' % cmake_build_dir,
-                'cd %s' % cmake_build_dir,
-                ' '.join(cmake_cmds),
-                'env %s make install' % conda_evars]
-        sys.stdout.write('\n'.join(['[for cmake] '+cmd for cmd in cmds]))
-        sys.stdout.write('\n')
-        os.system(' ; '.join(cmds))
 
     with open('README.rst') as fobj:
         long_description = ''.join(fobj.read())

--- a/setup.py
+++ b/setup.py
@@ -311,11 +311,7 @@ def main():
             'solvcon.parcel.tests',
             'solvcon.parcel.vewave',
             'solvcon.tests',
-            'solvcon.vis',
         ],
-        package_data={
-            'solvcon.vis': ["js/*"],
-        },
         cmdclass={
             'build_ext': my_build_ext,
         },

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ def main():
                 '-Wno-unknown-pragmas',
             ],
         ),
-        CmakeExtension('solvcon.march', ['CMakeLists.txt']),
+        #CmakeExtension('solvcon.march', ['CMakeLists.txt']),
     ]
 
     # remove files when cleaning.

--- a/solvcon/__init__.py
+++ b/solvcon/__init__.py
@@ -94,6 +94,8 @@ from .helper import Gmsh
 from . import parcel
 from . import exception
 
+import_module_may_fail('.march')
+
 def test():
     """
     Run everything in :py:mod:`solvcon.tests` and :py:mod:`solvcon.io.tests`.

--- a/solvcon/dependency.py
+++ b/solvcon/dependency.py
@@ -36,6 +36,16 @@ Logic for using external compiled libraries.
 import warnings
 import importlib
 import inspect
+import re
+
+
+def _import_libmarch():
+    try:
+        import libmarch
+    except ImportError:
+        libmarch = None
+        warnings.warn("libmarch not found", RuntimeWarning, stacklevel=2)
+    return libmarch
 
 
 def resolve_name(name, package):
@@ -52,6 +62,7 @@ def resolve_name(name, package):
         name = util.resolve_name(name, package)
     return name
 
+_libmarch_name_pattern = re.compile(r'\.+march')
 
 def import_module_may_fail(modname, asname=None):
     """
@@ -64,8 +75,10 @@ def import_module_may_fail(modname, asname=None):
     cframe = inspect.currentframe().f_back # Caller's frame.
     try:
         cglobals = cframe.f_globals
-        # Determine package name for importlib.import_module().
-        if modname.startswith('.'):
+        if _libmarch_name_pattern.search(modname):
+            package = _import_libmarch # call this method later.
+        elif modname.startswith('.'):
+            # Determine package name for importlib.import_module().
             package = cglobals['__name__']
             if not cglobals['__file__'].split('.')[-2].endswith('__init__'):
                 package = '.'.join(package.split('.')[:-1])
@@ -75,7 +88,10 @@ def import_module_may_fail(modname, asname=None):
         asname = modname.split('.')[-1] if None is asname else asname
         # Try to import the module.
         try:
-            mod = importlib.import_module(modname, package)
+            if callable(package):
+                mod = package()
+            else:
+                mod = importlib.import_module(modname, package)
             if '' != asname:
                 cframe.f_locals[asname] = mod
         except ImportError as e:

--- a/solvcon/helper.py
+++ b/solvcon/helper.py
@@ -167,8 +167,13 @@ def get_username():
         username = os.getlogin()
     except:
         username = None
+    import getpass
+    try:
+        username = getpass.getuser()
+    except:
+        username = None
     if not username:
-        username = os.environ['LOGNAME']
+        username = os.environ.get('LOGNAME')
     return username
 
 def search_in_parents(loc, name):

--- a/solvcon/tests/test_march.py
+++ b/solvcon/tests/test_march.py
@@ -15,7 +15,7 @@ from ..testing import get_blk_from_oblique_neu, get_blk_from_sample_neu
 class TestCreation(TestCase):
 
     def test_import(self):
-        from solvcon.march import gas
+        from libmarch import gas
 
     def test_constructor(self):
         svr = march.gas.Solver2D(
@@ -30,7 +30,6 @@ class TestCreation(TestCase):
 class TestGasSolver(TestCase):
 
     def test_class_attributes(self):
-        from solvcon.march import gas
-        for cls in (gas.Solver2D, gas.Solver3D):
+        for cls in (march.gas.Solver2D, march.gas.Solver3D):
             self.assertEqual(getattr(cls, '_interface_init_'), ('cecnd',))
             self.assertEqual(getattr(cls, '_solution_array_'), tuple())

--- a/solvcon/tests/test_table.py
+++ b/solvcon/tests/test_table.py
@@ -32,7 +32,7 @@ import unittest
 
 import numpy as np
 
-from ..march import Table
+from solvcon import Table
 
 
 class TestTableCreation(unittest.TestCase):


### PR DESCRIPTION
This PR cleans up the build system so that libmarch can be built standalone and work as a standalone Python extension module.  Solvcon imports it from top-level namespace.

This is to make future development more efficient.  For now I'd like to stick with C++11 and pybind11 for low-level code.  The legacy C, Cython, and ctype code should be deprecated and new code goes to `libmarch/`.

Building directives need update as well.  I may add additional changes to this PR or use another one.