### PR TITLE
Install libraries in a more generic path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PKGNAME := SOLVCON-${SCVER}
 
 BUILD_DIR := ${LIBMARCH_PATH}/build/${BUILD_DIR_NAME}
 
-PREFIX ?= ./opt
+PREFIX ?= $(realpath $(dir ${PYTHON})/../)
 INSTALL_TO_DEBIAN ?=
 ifeq (${INSTALL_TO_DEBIAN},)
 	PYTHON_LIBRARY_DIR := ${PREFIX}/lib/$(shell ${PYTHON} -c "import sys; print('python%d.%d'%sys.version_info[:2])")/site-packages


### PR DESCRIPTION
This generic path is more useful for maintaining a python virtual environment rather than a hard-coded path.

For example, I use conda to create a python virtual environment, and then do everything (build and install the library) in the virtual environment. I don't need to tell where to find the built *.so over PYTHONPATH because they (the *.so) have been already installed into my python environment.