### PR TITLE
Update README to guide users to build libmarch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,11 @@ To install the dependency, run the scripts ``contrib/conda.sh`` and
 
 The development version of SOLVCON only supports local build::
 
-  $ python setup.py build_ext --inplace
+  $ make; python setup.py build_ext --inplace
+
+To build SOLVCON from source code and install it to your system::
+
+  $ make; make install
 
 Test the build::
 


### PR DESCRIPTION
The current README does not tell users to build libmarch.so. This commit add the information. Besides, users could install the built *.so into the expected folder by this merged PR https://github.com/solvcon/solvcon/pull/213 . Update this information to guide users to leverage the Makefile.