### PR TITLE
First singularity release on Singularity Hub

### DIFF
--- a/contrib/singularity/Singularity.0.1.0
+++ b/contrib/singularity/Singularity.0.1.0
@@ -1,0 +1,32 @@
+BootStrap: debootstrap
+OSVersion: xenial
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
+
+
+%runscript
+    echo "Welcome to SOLVCON singularity instance."
+
+%files
+    prepare-solvcon-dev.sh /prepare-solvcon-dev.sh
+
+%post
+    echo "Prepare to build SOLVCON in singularity instance..."
+    sed -i 's/$/ universe/' /etc/apt/sources.list
+    apt-get update
+    # general tools
+    apt-get install vim git -y
+    # used for miniconda extraction
+    apt-get install bzip2
+    # SOLVCON build tools
+    apt-get install openssh-client openssh-server liblapack-pic liblapack-dev -y
+    apt-get install build-essential unzip -y
+    # it currently works in the root path
+    echo "Working location: " `pwd`
+    # it is /root
+    echo $HOME
+    apt-get clean
+
+    # start to build
+    export SOLVCON_BUILD_DIR=/opt
+    /bin/bash -c "source /prepare-solvcon-dev.sh $SOLVCON_BUILD_DIR"
+


### PR DESCRIPTION
This commit just forks `contrib/singularity/Singularity` to be `contrib/singularity/Singularity.0.1.0`. [Singularity Hub](www.singularity-hub.org) uses filename extension to coincide on the tag of each built images.

This is the first step of our Singularity image CI. We will keep evolving `Singularity`, which is `latest` tag when pulling images, and freeze each of the released images with the names e.g. `Singularity.x.x.x`. Please refer to [Singularity Hub documentation](https://github.com/singularityhub/singularityhub.github.io/wiki/Build-A-Container) for more details.