### PR TITLE
Activate virtual environment created by conda in the Singularity container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ sandbox/*/mesh/
 # debian packaging
 debian/files
 debian/solvcon*
+# Singularity images
+*.img
+*.simg

--- a/contrib/singularity/README.rst
+++ b/contrib/singularity/README.rst
@@ -9,12 +9,6 @@ Pre-requisite
 
 Install `Singularity <http://singularity.lbl.gov/>`_.
 
-Create a file `host-username.txt` by
-
-  $ whoami > /tmp/host-username.txt
-
-This is a trick for you to touch the SOLVCON folder in the container later after building the singularity image.
-
 This instruction is verified by running on Ubuntu Xenial.
 
 Build
@@ -31,15 +25,11 @@ Use the Container
 
 Use the container by
 
-  $ singularity shell --home <your-directory-used-as-container-home> ./<name-of-the-image>.img
-
-Activate the runtime by
-
-  [container] :SOLVCON-SRC-ROOT> source /opt/solvcon/contrib/singularity/activate.sh
+  $ singularity shell ./<name-of-the-image>.img
 
 Now you can develop your driving script and use SOLVCON.
 
-So far the feature of parallel mode does not work in the singularity container. Please note the option `--home` is recommended. To use a clean directory as your home in the container will help you to avoid many python virtual environment issues, e.g. conda is confused by your configuration files in your host home directory.
+So far the feature of parallel mode does not work in the singularity container.
 
-You could refer to `contrib/singularity/sod-tube` to see how a SOLVCON driving script works with the container, and how `build-solvcon.sh` leverages it.
+If you use `build-solvcon.sh` to build the image, you could follow the instruction of build message at the end of the build script to run an example.
 

--- a/contrib/singularity/README.rst
+++ b/contrib/singularity/README.rst
@@ -31,5 +31,5 @@ Now you can develop your driving script and use SOLVCON.
 
 So far the feature of parallel mode does not work in the singularity container.
 
-If you use `build-solvcon.sh` to build the image, you could follow the instruction of build message at the end of the build script to run an example.
+If you use `build-solvcon.sh` to build the image, you could follow the instruction of the build message at the end of the build script to run an example.
 

--- a/contrib/singularity/Singularity
+++ b/contrib/singularity/Singularity
@@ -3,6 +3,10 @@ OSVersion: xenial
 MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 
 
+%environment
+    export SOLVCON_WORKING_DIR=/opt/solvcon-working
+    export PATH="$SOLVCON_WORKING_DIR/venv-conda/bin:$SOLVCON_WORKING_DIR/miniconda/bin:$PATH"
+
 %runscript
     echo "Welcome to SOLVCON singularity instance."
 

--- a/contrib/singularity/Singularity.1.0.0-0.1.4+
+++ b/contrib/singularity/Singularity.1.0.0-0.1.4+
@@ -1,0 +1,36 @@
+BootStrap: debootstrap
+OSVersion: xenial
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
+
+
+%environment
+    export SOLVCON_WORKING_DIR=/opt/solvcon-working
+    export PATH="$SOLVCON_WORKING_DIR/venv-conda/bin:$SOLVCON_WORKING_DIR/miniconda/bin:$PATH"
+
+%runscript
+    echo "Welcome to SOLVCON singularity instance."
+
+%files
+    prepare-solvcon-dev.sh /prepare-solvcon-dev.sh
+
+%post
+    echo "Prepare to build SOLVCON in singularity instance..."
+    sed -i 's/$/ universe/' /etc/apt/sources.list
+    apt-get update
+    # general tools
+    apt-get install vim git -y
+    # used for miniconda extraction
+    apt-get install bzip2
+    # SOLVCON build tools
+    apt-get install openssh-client openssh-server liblapack-pic liblapack-dev -y
+    apt-get install build-essential unzip -y
+    # it currently works in the root path
+    echo "Working location: " `pwd`
+    # it is /root
+    echo $HOME
+    apt-get clean
+
+    # start to build
+    export SOLVCON_BUILD_DIR=/opt
+    /bin/bash -c "source /prepare-solvcon-dev.sh $SOLVCON_BUILD_DIR"
+

--- a/contrib/singularity/activate.sh
+++ b/contrib/singularity/activate.sh
@@ -1,3 +1,0 @@
-export SOLVCON_WORKING_DIR=/opt/solvcon-working
-export PATH="$SOLVCON_WORKING_DIR/miniconda/bin:$PATH"
-source activate $SOLVCON_WORKING_DIR/venv-conda

--- a/contrib/singularity/build-solvcon.sh
+++ b/contrib/singularity/build-solvcon.sh
@@ -26,7 +26,7 @@ cp ${SCSRC}/contrib/singularity/sod-tube ${EXAMPLE_TUBE}
 sudo singularity build $SIMAGE ./Singularity
 
 # run examples
-SJOB_COMMAND="singularity exec --home ${SHOME} ${SIMAGE} ${EXAMPLE_TUBE}/sod-tube ${SHOME}"
+SJOB_COMMAND="singularity exec --home ${SHOME} ${SIMAGE} ${EXAMPLE_TUBE}/sod-tube"
 
 echo ""
 echo "======================================================================"

--- a/contrib/singularity/build-solvcon.sh
+++ b/contrib/singularity/build-solvcon.sh
@@ -26,7 +26,8 @@ cp ${SCSRC}/contrib/singularity/sod-tube ${EXAMPLE_TUBE}
 sudo singularity build $SIMAGE ./Singularity
 
 # run examples
-SJOB_COMMAND="singularity exec --home ${SHOME} ${SIMAGE} ${EXAMPLE_TUBE}/sod-tube"
+SJOB_COMMAND="singularity exec --home ${SHOME} ${SIMAGE} tube/sod-tube"
+SJOB_COMMAND_ALT="singularity exec ${SIMAGE} go run"
 
 echo ""
 echo "======================================================================"
@@ -36,5 +37,12 @@ echo ""
 echo "${SJOB_COMMAND}"
 echo ""
 echo "The generated data will be in ${EXAMPLE_TUBE}/result"
+echo ""
+echo "Or, you could go to somewhere containing your driving script,"
+echo "and execute it like the follwing:"
+echo ""
+echo "${SJOB_COMMAND_ALT}"
+echo ""
+echo "The driving script, go, is executed along with its option, run."
 echo "======================================================================"
 

--- a/contrib/singularity/build-solvcon.sh
+++ b/contrib/singularity/build-solvcon.sh
@@ -27,7 +27,7 @@ sudo singularity build $SIMAGE ./Singularity
 
 # run examples
 SJOB_COMMAND="singularity exec --home ${SHOME} ${SIMAGE} tube/sod-tube"
-SJOB_COMMAND_ALT="singularity exec ${SIMAGE} go run"
+SJOB_COMMAND_ALT="singularity exec ${SIMAGE} ./go run"
 
 echo ""
 echo "======================================================================"

--- a/contrib/singularity/prepare-solvcon-dev.sh
+++ b/contrib/singularity/prepare-solvcon-dev.sh
@@ -42,7 +42,9 @@ echo "======================================"
 echo "Start to unit tests and function tests"
 echo "======================================"
 nosetests --with-doctest
+test_result_nose_doctest=$?
 nosetests ftests/gasplus/*
+test_result_ftests_gasplus=$?
 
 # If unit tests and function tests are good
 # install SOLVCON and remove intermediate files
@@ -76,4 +78,19 @@ echo ${PYTHONPATH}
 which conda
 which python
 conda env list
+
+# -n is "if it is not 0"
+if [ -n "${test_result_nose_doctest}" ] && [ -n "${test_result_ftests_gasplus}" ]; then
+  echo ""
+  echo "========================="
+  echo "Build test is successful."
+  echo "========================="
+  echo ""
+else
+  echo ""
+  echo "=================="
+  echo "Build test failed."
+  echo "=================="
+  echo ""
+fi
 

--- a/contrib/singularity/sod-tube
+++ b/contrib/singularity/sod-tube
@@ -1,6 +1,4 @@
 #!/bin/bash
-SHOME="${1:-/tmp/${USER}-singularity}"
-source /opt/solvcon/contrib/singularity/activate.sh
-cd ${SHOME}/tube
+cd ${HOME}/tube
 ./go run
 


### PR DESCRIPTION
This PR activates the virtual environment in the Singularity container by default. Users could run their own pure-SOLVCON[1] driving scripts outside the container. In the meantime, tag the singularity file as Singularity.1.0.0-0.1.4+ by forking Singularity.[2][3]

[1] Driving scripts without lines to activate the virtual environment at the very beginning. 
[2] The image build could be found and download here https://singularity-hub.org/collections/1679
[3] An open question: what the tag naming rules we should follow? Currently it does not impact very much because we did not bump SOLVCON version very frequently.