### PR TITLE
Fix Travis-CI error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,9 +185,9 @@ def main():
                 data_files.append((os.path.join(lead, edir),
                     glob.glob(os.path.join(edir, '*.%s'%ext))))
 
-    turn_off_unused_warnings = '-Wno-unused-variable'
+    turn_off_unused_warnings = ['-Wno-unused-variable']
     if sys.platform != 'darwin':
-        turn_off_unused_warnings += ' -Wno-unused-but-set-variable'
+        turn_off_unused_warnings += ['-Wno-unused-but-set-variable']
     # set up extension modules.
     lapack_libraries = ['lapack', 'blas']
     if os.environ.get('LAPACK_GFORTRAN'):
@@ -204,23 +204,19 @@ def main():
         make_cython_extension(
             'solvcon.parcel.fake._algorithm',
             ['src'],
-            extra_compile_args=[
-                turn_off_unused_warnings,
-            ],
+            extra_compile_args=turn_off_unused_warnings,
         ),
         make_cython_extension(
             'solvcon.parcel.linear._algorithm', ['src'],
             libraries=lapack_libraries,
-            extra_compile_args=[
-                turn_off_unused_warnings,
+            extra_compile_args=turn_off_unused_warnings + [
                 '-Wno-unknown-pragmas',
             ],
         ),
         make_cython_extension(
             'solvcon.parcel.bulk._algorithm',
             ['src'],
-            extra_compile_args=[
-                turn_off_unused_warnings,
+            extra_compile_args=turn_off_unused_warnings + [
                 '-Wno-unknown-pragmas',
                 '-Wno-uninitialized',
             ],
@@ -228,16 +224,14 @@ def main():
         make_cython_extension(
             'solvcon.parcel.gas._algorithm',
             ['src'],
-            extra_compile_args=[
-                turn_off_unused_warnings,
+            extra_compile_args=turn_off_unused_warnings + [
                 '-Wno-unknown-pragmas',
             ],
         ),
         make_cython_extension(
             'solvcon.parcel.vewave._algorithm', ['src'],
             libraries=['lapack', 'blas'],
-            extra_compile_args=[
-                turn_off_unused_warnings,
+            extra_compile_args=turn_off_unused_warnings + [
                 '-Wno-unknown-pragmas',
             ],
         ),


### PR DESCRIPTION
distutil somehow fed `-Wno-unused-variable -Wno-unused-but-set-variable` to gcc as a single string and travis trusty (and xenial) image gives error at build 
`#261` (https://travis-ci.org/solvcon/solvcon/jobs/500695741) (`#260` 
https://travis-ci.org/solvcon/solvcon/jobs/497384249 had been fine with the same code):

```
cc1: error: unrecognized command line option "-Wno-unused-variable -Wno-unused-but-set-variable" [-Werror]
```

This PR makes `turn_off_unused_warnings` a list (in setup.py) to work around it.