### PR TITLE
travis CI: update to Xenial for Trusty EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: xenial
 
 cache:
   directory:


### PR DESCRIPTION
Ubuntu Trusty has reached its end of life. Let's bump our build system to be Xenial.