### PR TITLE
Issue #226: init ndstf array elements

### DIFF
--- a/solvcon/src/sc_mesh_calc_metric.c
+++ b/solvcon/src/sc_mesh_calc_metric.c
@@ -53,7 +53,7 @@ int sc_mesh_calc_metric(sc_mesh_t *msd, int use_incenter) {
     double vol, vob, voc;
     double du0, du1, du2, dv0, dv1, dv2, dw0, dw1, dw2;
     // arrays.
-    int ndstf[FCMND];
+    int ndstf[FCMND] = {0};
     double cfd[FCMND+2][msd->ndim];
     double crd[msd->ndim];
     double radvec[FCMND][msd->ndim];


### PR DESCRIPTION
The following tests have been validated on Bionic for the fix of Issue: #226 

- [x] `nosetests --with-doctest`
- [x] `nosetests ftests/gasplus/*`
- [x] `solvcon/sandbox/gas/tube/go run` visualization

I did not bump the build system of Travis CI to be `bionic` for the validation of this fix on Xenial over Travis CI. If we are ok with the Bionic update, we could move forward to bionic anytime later. 