### PR TITLE
Bump cmake minimum version to 3.7 to follow the pybind11 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Yung-Yu Chen <yyc@solvcon.net>
 # BSD 3-Clause License, see LICENSE.txt
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.7)
 project(solvcon)
 
 option(SOLVCON_ROOT "SOLVCON root path" OFF)

--- a/libmarch/CMakeLists.txt
+++ b/libmarch/CMakeLists.txt
@@ -10,7 +10,7 @@
 #
 #   $ mkdir -p build/xcode; cd build/xcode; cmake -G Xcode ../..
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.7)
 project(libmarch)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
@@ -20,6 +20,8 @@ option(MARCH_RELAX_ERROR "Relax compiler error" OFF)
 option(MARCH_NO_DEPRECATE_WARNING "Turn off deprecation warning" OFF)
 option(MARCH_DESTINATION "SOLVCON root path" OFF)
 option(MARCH_TEST "Build libmarch test cases" ON)
+
+cmake_policy(SET CMP0074 NEW)
 
 find_package(SCOTCH)
 

--- a/libmarch/src/python/CMakeLists.txt
+++ b/libmarch/src/python/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Copyright (c) 2017, Yung-Yu Chen <yyc@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.7)
 project(march)
+
+cmake_policy(SET CMP0069 NEW)
 
 #add_subdirectory(pybind11)
 find_package(pybind11 REQUIRED)


### PR DESCRIPTION
See https://github.com/pybind/pybind11/pull/2338

Add CMP0069 (addressing the pybind11 cmake update for IPO) and CMP0074 at right places.