### PR TITLE
sandbox: gas: tube: increase averaged maximum CFL

### DIFF
--- a/sandbox/gas/tube/go
+++ b/sandbox/gas/tube/go
@@ -270,7 +270,7 @@ def tube(casename, **kw):
         rho1=1.0, p1=1.0,
         rho2=0.125, p2=0.1,
         # Arguments to GasCase.
-        time_increment=7.e-4, steps_run=600, **kw)
+        time_increment=1.65e-3, steps_run=600, **kw)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By tuning the driving script, we could optimize CFLs of each march and
loop. The averaged maximum CFL is improved from 0.286695 to 0.736332.

Running with CPU i5-8265U, Ubuntu mate 18.04, in sequential mode.

issue #128

# Steps to Test This Pull Request
Go to `solvcon/sandbox/gas/tube` and invoke `./go run`.

# Expected Results
## As is
```
*** *** Step 584/600, 13.5s elapsed, 0.4s left
*** *** CFL = 0.07/0.40 - 0.06/0.42 adjusted: 0/0/0
*** *** Performance of tube:
*** ***   13.4802 seconds in marching solver.
*** ***   0.0230825 seconds/step.
*** ***   6.09518 microseconds/cell.
*** ***   0.164064 Mcells/seconds.
*** ***   0.82032 Mvariables/seconds.
*** *** ##
*** *** Step 592/600, 13.7s elapsed, 0.2s left
*** *** CFL = 0.08/0.40 - 0.06/0.42 adjusted: 0/0/0
*** *** Performance of tube:
*** ***   13.6513 seconds in marching solver.
*** ***   0.0230596 seconds/step.
*** ***   6.08914 microseconds/cell.
*** ***   0.164227 Mcells/seconds.
*** ***   0.821134 Mvariables/seconds.
*** *** ##
*** *** Step 600/600, 13.9s elapsed, 0.0s left
*** *** CFL = 0.08/0.40 - 0.06/0.42 adjusted: 0/0/0
*** *** ************************************************************************
*** *** End run_march . Elapsed time (sec) = 13.8993
*** ****************************************************************************
*** 
*** ****************************************************************************
*** *** Start run_postloop ... 
*** *** ************************************************************************
*** *** Probe result at Pt/0#2014(0,0,0)601:
*** *** - rho = 0.970 
*** *** - v = 0.015 
*** *** - p = 0.958 
*** *** Performance of tube:
*** ***   13.8375 seconds in marching solver.
*** ***   0.0230625 seconds/step.
*** ***   6.08991 microseconds/cell.
*** ***   0.164206 Mcells/seconds.
*** ***   0.82103 Mvariables/seconds.
*** *** Averaged maximum CFL = 0.286695.
```


## To be
```
*** *** Step 584/600, 12.9s elapsed, 0.4s left
*** *** CFL = 0.21/0.71 - 0.15/0.99 adjusted: 0/0/0
*** *** Performance of tube:
*** ***   12.8693 seconds in marching solver.
*** ***   0.0220365 seconds/step.
*** ***   5.81898 microseconds/cell.
*** ***   0.171851 Mcells/seconds.
*** ***   0.859257 Mvariables/seconds.
*** *** ##
*** *** Step 592/600, 13.1s elapsed, 0.2s left
*** *** CFL = 0.21/0.71 - 0.15/0.99 adjusted: 0/0/0
*** *** Performance of tube:
*** ***   13.0406 seconds in marching solver.
*** ***   0.0220281 seconds/step.
*** ***   5.81676 microseconds/cell.
*** ***   0.171917 Mcells/seconds.
*** ***   0.859585 Mvariables/seconds.
*** *** ##
*** *** Step 600/600, 13.3s elapsed, 0.0s left
*** *** CFL = 0.21/0.70 - 0.15/0.99 adjusted: 0/0/0
*** *** ************************************************************************
*** *** End run_march . Elapsed time (sec) = 13.284
*** ****************************************************************************
***
*** ****************************************************************************
*** *** Start run_postloop ...
*** *** ************************************************************************
*** *** Probe result at Pt/0#2014(0,0,0)601:
*** *** - rho = 0.506
*** *** - v = 0.430
*** *** - p = 0.385
*** *** Performance of tube:
*** ***   13.222 seconds in marching solver.
*** ***   0.0220367 seconds/step.
*** ***   5.81905 microseconds/cell.
*** ***   0.171849 Mcells/seconds.
*** ***   0.859247 Mvariables/seconds.
*** *** Averaged maximum CFL = 0.736332.
```