### PR TITLE
Run SOLVCON with Python 3.8 by default

### DIFF
--- a/.github/workflows/solvcon_install.yml
+++ b/.github/workflows/solvcon_install.yml
@@ -42,7 +42,7 @@ jobs:
         fi
         bash miniconda.sh -u -b -p $HOME/miniconda
         export PATH="$HOME/miniconda/bin:$PATH"
-        echo "::set-env name=PATH::$PATH"
+        echo "PATH=$PATH" >> $GITHUB_ENV
         hash -r
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda

--- a/contrib/conda.sh
+++ b/contrib/conda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 conda install -y \
-  python=3.6 \
+  python=3.8 \
   cmake setuptools pip sphinx ipython jupyter \
   cython numpy hdf4 netcdf4 nose pytest paramiko boto graphviz
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi


### PR DESCRIPTION
Python 3.6 will be end of life by the end of 2021. Let's bump the default conda python version when building the development and runtime environment.

# Steps to Verify This Pull Request
1. Build the environment as usual with conda (please refer to `.github/workflows/solvcon_install.yml`)
2. Launch the usual test cases, e.g. `nosetests --with-doctest; nosetests ftests/gasplus/*`
3. `cd solvcon/sandbox/gas/tube; ./go run`

# Expected Results
In step 2 we will get:

```
.............................................................................................................................................................................................................................................
......................................................................................................................................................SSS
----------------------------------------------------------------------
Ran 390 tests in 7.601s

OK (SKIP=3)
.
----------------------------------------------------------------------
Ran 1 test in 0.303s

OK
```

In step 3 we will get the solution of Sod tube problem:
```
*** *** Probe result at Pt/0#1820(0,0,0)601:                                    
*** *** - rho = 0.501                                    
*** *** - v = 0.422                                                             
*** *** - p = 0.380                                                             
*** *** Performance of tube:                           
*** ***   12.4761 seconds in marching solver.                                   
*** ***   0.0207935 seconds/step.                                               
*** ***   5.52139 microseconds/cell.                                          
*** ***   0.181114 Mcells/seconds.                                                                 
*** ***   0.90557 Mvariables/seconds.                                           
*** *** Averaged maximum CFL = 0.740691.
```


In my case, the build-from-scratch environment with mini-conda will offer us Python 3.8.2.