### PR TITLE
ci(action): update for CVE-2020-15228

### DIFF
--- a/.github/workflows/solvcon_install.yml
+++ b/.github/workflows/solvcon_install.yml
@@ -42,7 +42,7 @@ jobs:
         fi
         bash miniconda.sh -u -b -p $HOME/miniconda
         export PATH="$HOME/miniconda/bin:$PATH"
-        echo "::set-env name=PATH::$PATH"
+        echo "PATH=$PATH" >> $GITHUB_ENV
         hash -r
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda


### PR DESCRIPTION
To avoid CVE-2020-15228 Github disabled set-env and suggests to use the
new environment files. See the announcement of Github for more details
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands