### PR TITLE
Maintenance checkin for macos 11.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 tags
+setup.mk
 setup.cfg
 build/
 build.dbg/

--- a/solvcon/connection.py
+++ b/solvcon/connection.py
@@ -32,7 +32,6 @@
 Remote connection and communication.
 """
 
-
 def pick_unused_port():
     """
     Use socket to find out a unused (inet) port.
@@ -193,6 +192,7 @@ def Client(address, family=None, authkey=None):
         try:
             skt.connect(address)
         except socket.error as e:
+            skt.close()
             if e.args[0] != errno.ECONNREFUSED or time.time() > timeout:
                 raise
             time.sleep(0.01)

--- a/solvcon/helper.py
+++ b/solvcon/helper.py
@@ -296,7 +296,7 @@ class Gmsh(object):
         cmdf.write('\n')
         cmdf.close()
         # call Gmsh and get the data.
-        cli = 'gmsh %s -3 -o %s' % (cmdp, mshp)
+        cli = 'gmsh %s -3 -format msh22 -o %s' % (cmdp, mshp)
         if None is not options:
             cli += ' %s' % options
         pobj = Popen(shlex.split(cli), stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
Improve the makefile to workaround macos system integrity protection.

Close socket after having the exception to remove the warning.

Force Gmsh helper to use version 2.2 output file format.  This should address issue #236.