### PR TITLE
ci(github): migrate packages from conda to devenv

### DIFF
--- a/contrib/conda.sh
+++ b/contrib/conda.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 conda install -y \
   python=3.8 \
-  cmake setuptools pip sphinx ipython jupyter \
-  cython numpy hdf4 netcdf4 nose pytest paramiko boto graphviz
+  cmake \
+  numpy hdf4 netcdf4 nose boto paramiko
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
 conda install -y -c https://conda.anaconda.org/yungyuc scotch
-lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
-pip install pybind11 pythreejs
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi


### PR DESCRIPTION
Migrating more packages from conda to devenv for issue: #242 .

CI will fail if we remove the remaining packages in `contrib/conda.sh`, and how to integrate all of them will be kept studying.