### PR TITLE
build(setup.py): search external lib for devenv integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,8 +116,15 @@ def make_cython_extension(
         '-Wno-cpp' if sys.platform != 'darwin' else '-Wno-#warnings',
         '-Wno-unused-function',
     ] + extra_compile_args
+
+    if sys.platform == 'darwin':
+        lib_search_path = os.getenv("DYLD_LIBRARY_PATH", "/usr/lib")
+    else:
+        lib_search_path = os.getenv("LD_LIBRARY_PATH", "/usr/lib")
+
     return CyExtension(
         name, files,
+        library_dirs=lib_search_path.split(':'),
         include_dirs=include_dirs,
         libraries=libraries,
         extra_compile_args=extra_compile_args,


### PR DESCRIPTION
We are going to integrate `devenv` issue: #242 for building our stack. This pull request makes`setup.py` to include external libraries which are built and prepared by `devenv` when building extensions.

This solution is based on `library_dirs` option of https://docs.python.org/3/distutils/setupscript.html#library-options .

Please notice the document warns us with this statement: `Again, this sort of non-portable construct should be avoided if you intend to distribute your code.` I am not sure if the current pull request is good enough in our use case, which we are specifically aim at the distribution for POSIX compliant OS including OSX.

A possible alternative solution is use `-L` in Makefile for `.PHONY: legacy` or something similar. Simply appending `-L` does not help for `make install` because `setup.py install` seems to call building definition of `setup.py` directly and no way to tell where to include `-L` additionally.