### PR TITLE
ci(devenv): fully build SOLVCON with devenv

### DIFF
--- a/.github/workflows/solvcon_install.yml
+++ b/.github/workflows/solvcon_install.yml
@@ -28,11 +28,8 @@ jobs:
       run: |
         sudo apt-get -qqy update
         sudo apt-get -qqy install fakeroot debhelper locales \
-                libreadline7 libssl1.0.0 libffi6 \
-                liblapack3 liblapack-dev libhdf5-100 libhdf5-dev libnetcdf13 \
-                libnetcdf-dev libscotch-6.0 libscotch-dev python3 \
-                python3-numpy libpython3.6-dev python3-boto python3-paramiko graphviz
-
+                libffi6 \
+                liblapack3 liblapack-dev
     - name: dependency (devenv)
       run: |
         git clone https://github.com/solvcon/devenv.git
@@ -40,36 +37,7 @@ jobs:
         devenv add prime
         devenv use prime
         devenv show
-        mkdir -p ${GITHUB_WORKSPACE}/devenv/flavors/prime/usr/bin
-        devenv build gmsh
-
-    - name: dependency (conda)
-      run: |
-        if [[ "$(uname)" == "Darwin" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        fi
-        bash miniconda.sh -u -b -p $HOME/miniconda
-        export PATH="$HOME/miniconda/bin:$PATH"
-        echo "PATH=$PATH" >> $GITHUB_ENV
-        hash -r
-        conda config --set always_yes yes --set changeps1 no
-        conda update -q conda
-        # Install conda packages
-        ${GITHUB_WORKSPACE}/contrib/devenv/create.sh
-        source ${GITHUB_WORKSPACE}/build/env/start
-        ${GITHUB_WORKSPACE}/contrib/conda.sh
-        ${GITHUB_WORKSPACE}/contrib/build-pybind11-in-conda.sh
-        # Debugging information
-        conda info -a
-        conda list
-
-        PYTHON_EXE=$(which python)
-        # specify python3
-        source ${GITHUB_WORKSPACE}/devenv/scripts/init
-        devenv use prime
-        PYTHON_EXE=${PYTHON_EXE} devenv build cython
+        devenv launch solvcon
 
     - name: configure ssh
       if: matrix.os == 'disable'
@@ -90,7 +58,6 @@ jobs:
         source ${GITHUB_WORKSPACE}/devenv/scripts/init
         devenv use prime
         devenv show
-        source ${GITHUB_WORKSPACE}/build/env/start
         export
         which gcc
         gcc --version
@@ -106,7 +73,6 @@ jobs:
         source ${GITHUB_WORKSPACE}/devenv/scripts/init
         devenv use prime
         devenv show
-        source ${GITHUB_WORKSPACE}/build/env/start
         which python3
         python3 --version
         python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
@@ -123,5 +89,4 @@ jobs:
         source ${GITHUB_WORKSPACE}/devenv/scripts/init
         devenv use prime
         devenv show
-        source ${GITHUB_WORKSPACE}/build/env/start
         make SC_PURE_PYTHON=1 test_from_package


### PR DESCRIPTION
The latest devenv begins to support SOLVCON build fully
https://github.com/solvcon/devenv/pull/91 . It means that conda is not
necessary anymore. Thus we can run our CI with devenv fully without
conda.