### PR TITLE
ci(devenv): re-use scripts from devenv

### DIFF
--- a/.github/workflows/solvcon_install.yml
+++ b/.github/workflows/solvcon_install.yml
@@ -1,4 +1,4 @@
-name: solvcon_install
+name: Build with Conda
 
 on:
   push:

--- a/.github/workflows/solvcon_install.yml
+++ b/.github/workflows/solvcon_install.yml
@@ -1,4 +1,5 @@
-name: Build with Conda
+# Build SOLVCON with Conda
+name: solvcon_install
 
 on:
   push:

--- a/.github/workflows/solvcon_install_devenv.yml
+++ b/.github/workflows/solvcon_install_devenv.yml
@@ -1,90 +1,45 @@
-name: solvcon_install_devenv
-
+name: Build with devenv
 on:
   schedule:
     - cron: '21 18 * * 5'
-
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
-
     strategy:
         matrix:
-          os: [ubuntu-18.04, macos-latest]
-
+          os: [ubuntu-20.04, macos-latest]
         fail-fast: false
-
     steps:
-
-    - uses: actions/checkout@v1
+    - name: Checkout Repository
+      uses: actions/checkout@v2
       with:
         fetch-depth: 1
-
-    - name: dependency (ubuntu)
-      if: matrix.os != 'macos-latest'
-      run: |
-        sudo apt-get -qqy update
-        sudo apt-get -qqy install fakeroot debhelper locales \
-                libffi6 \
-                liblapack3 liblapack-dev
-    - name: dependency (devenv)
+    - name: Set DEVENV_WORKSPACE
+      run: echo "DEVENV_WORKSPACE=${GITHUB_WORKSPACE}/devenv" >> $GITHUB_ENV
+    - name: Dependency (devenv)
       run: |
         git clone https://github.com/solvcon/devenv.git
-        source ${GITHUB_WORKSPACE}/devenv/scripts/init
+    - name: Configure SSH
+      if: matrix.os == 'disable'
+      run: |
+        source ${DEVENV_WORKSPACE}/contrib/ci-setup-ssh.sh
+    - name: Dependency (Ubuntu)
+      if: matrix.os != 'macos-latest'
+      run: |
+        source ${DEVENV_WORKSPACE}/contrib/ci-setup-apt.sh
+    - name: Launch SOLVCON
+      run: |
+        source ${DEVENV_WORKSPACE}/scripts/init
         devenv add prime
         devenv use prime
         devenv show
         devenv launch solvcon
-
-    - name: configure ssh
-      if: matrix.os == 'disable'
+    - name: Show Dependency
       run: |
-        ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
-        chmod 700 ~/.ssh/
-        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        chmod 600 ~/.ssh/authorized_keys
-        ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
-        ssh-keyscan -t rsa 127.0.0.1 >> ~/.ssh/known_hosts
-        chmod 600 ~/.ssh/known_hosts
-        ls -al ~/.ssh/
-        ssh localhost ls
-        ssh 127.0.0.1 ls
-
-    - name: show dependency
+        source ${DEVENV_WORKSPACE}/contrib/ci-show-dep.sh
+    - name: Show Python Env
       run: |
-        source ${GITHUB_WORKSPACE}/devenv/scripts/init
-        devenv use prime
-        devenv show
-        export
-        which gcc
-        gcc --version
-        which cmake
-        cmake --version
-        which python3
-        python3 --version
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        which gmsh
-
-    - name: show python env
+        source ${DEVENV_WORKSPACE}/contrib/ci-show-python-env.sh
+    - name: SOLVCON Function Test From Package
       run: |
-        source ${GITHUB_WORKSPACE}/devenv/scripts/init
-        devenv use prime
-        devenv show
-        which python3
-        python3 --version
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        python3 -c 'import sys ; print(sys.path)'
-        echo "==============="
-        echo "python globals:"
-        python3 -c 'import numpy, solvcon ; print(globals())'
-        echo "==============="
-        echo "python locals:"
-        python3 -c 'import numpy, solvcon ; print(locals())'
-
-    - name: test from package
-      run: |
-        source ${GITHUB_WORKSPACE}/devenv/scripts/init
-        devenv use prime
-        devenv show
-        make SC_PURE_PYTHON=1 test_from_package
+        source ${DEVENV_WORKSPACE}/contrib/ci-solvcon-function-test.sh

--- a/.github/workflows/solvcon_install_devenv.yml
+++ b/.github/workflows/solvcon_install_devenv.yml
@@ -1,4 +1,5 @@
-name: Build with devenv
+# Build SOLVCON with devenv
+name: solvcon_install_devenv
 on:
   schedule:
     - cron: '21 18 * * 5'


### PR DESCRIPTION
Some helper scripts from devenv could be re-used to build SOLVCON with
devenv. By re-using these helper scripts, we can maintain the parity of
CI in both sides, devenv and SOLVCON, easier. (issue: #250)

For example, the recent CI failure when building SOLVCON with devenv
could be resolved directly by introducing the helper scripts from devenv
to resolve issue #249.

Some naming convention also follows the CI of devenv so we can compare
the result of the helper scripts in both sides easily as well.

Besides, bump Ubuntu version from 18.04 to 20.04. (issue: #251)

Issue: #249 #250 #251