### PR TITLE
Fix broken URL in README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 SOLVCON implements conservation-law solvers that use the space-time
 `Conservation Element and Solution Element (CESE) method
-<http://www.grc.nasa.gov/WWW/microbus/>`__.
+<http://cesehub.org/>`__.
 
 |rtd_status|
 


### PR DESCRIPTION
This URL in the README.rst [returns a 404](http://www.grc.nasa.gov/WWW/microbus/):
https://github.com/solvcon/solvcon/blob/bd9d3915dfd8b1c639e4fc8f733ecb93cedb80f3/README.rst#L1-L3

[grc.nasa.gov](https://www.grc.nasa.gov/) has been moved to https://www.nasa.gov/centers/glenn/home/index.html, however I wasn't able to find the corresponding page there.

Looking at the [Wayback Machine](http://web.archive.org/web/20190914053842/https://www.grc.nasa.gov/WWW/microbus/) I was able to find an old snapshot of the page, and then a page with the same content at http://cesehub.org/.

This PR replaces the broken URL with http://cesehub.org/.