### PR TITLE
Fix broken link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 SOLVCON implements conservation-law solvers that use the space-time
 `Conservation Element and Solution Element (CESE) method
-<http://cesehub.org/>`__.
+<https://yyc.solvcon.net/en/latest/cese/index.html>`__.
 
 |rtd_status|
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 SOLVCON implements conservation-law solvers that use the space-time
 `Conservation Element and Solution Element (CESE) method
-<http://www.grc.nasa.gov/WWW/microbus/>`__.
+<http://cesehub.org/>`__.
 
 |rtd_status|
 


### PR DESCRIPTION
This is a follow-up of:
* #259 
* #262 

#262 fixed the URL in `doc/source/index.rst`, but the one in `README.rst` is still broken.  This PR updates the README using the same URL used in #262.
